### PR TITLE
fix: replace removed modelRegistry.authStorage API

### DIFF
--- a/kilo.ts
+++ b/kilo.ts
@@ -702,7 +702,7 @@ export default async function (pi: ExtensionAPI) {
   // After session starts, pre-fetch all models if already logged in so
   // modifyModels has data to work with. Also fetch and display credits.
   pi.on("session_start", async (_event, ctx) => {
-    const cred = ctx.modelRegistry.authStorage.get("kilo");
+    const cred = readStoredKiloCredentials();
 
     // Clear credits if not logged in
     if (cred?.type !== "oauth") {
@@ -755,7 +755,7 @@ export default async function (pi: ExtensionAPI) {
   pi.on("model_select", async (event, ctx) => {
     if (event.model?.provider !== "kilo") return;
 
-    const cred = ctx.modelRegistry.authStorage.get("kilo");
+    const cred = readStoredKiloCredentials();
     if (cred?.type !== "oauth") return;
 
     if (!ctx.hasUI) return;
@@ -779,7 +779,7 @@ export default async function (pi: ExtensionAPI) {
 
   // Refresh credits after each turn
   pi.on("turn_end", async (_event, ctx) => {
-    const cred = ctx.modelRegistry.authStorage.get("kilo");
+    const cred = readStoredKiloCredentials();
     if (cred?.type !== "oauth") return;
 
     if (!ctx.hasUI) return;
@@ -808,7 +808,7 @@ export default async function (pi: ExtensionAPI) {
     if (tosShown) return;
     if (ctx.model?.provider !== "kilo") return;
 
-    const cred = ctx.modelRegistry.authStorage.get("kilo");
+    const cred = readStoredKiloCredentials();
     if (cred?.type === "oauth") {
       tosShown = true;
       return;


### PR DESCRIPTION
pi 0.80.x removed the `authStorage` property from `ModelRegistry` (now a synchronous facade over `ModelRuntime`). The four event handlers crash with `Cannot read properties of undefined (reading 'get')` on every `turn_end`, `model_select`, `session_start`, and `before_agent_start`.

This PR replaces the removed API calls with the extension's existing `readStoredKiloCredentials()` helper, which reads `auth.json` directly. Behavior is otherwise unchanged.

Tested locally on pi 0.80.10 — the `turn_end` crash is gone and the credits status displays correctly.