### PR TITLE
fix: load the Kilo catalogue with KILO_API_KEY

### DIFF
--- a/kilo.ts
+++ b/kilo.ts
@@ -612,6 +612,7 @@ function makeProviderConfig(organizationId?: string) {
 
 export default async function (pi: ExtensionAPI) {
   const storedCredentials = readStoredKiloCredentials();
+  const startupCatalogToken = storedCredentials?.access ?? process.env.KILO_API_KEY;
   const startupOrganizationId = getEffectiveOrganizationId(storedCredentials);
 
   // Fetch models at load time so the provider is immediately usable for
@@ -619,9 +620,9 @@ export default async function (pi: ExtensionAPI) {
   let freeModels: ProviderModelConfig[] = [];
   let cachedAllModels: ProviderModelConfig[] = [];
   try {
-    if (storedCredentials?.access) {
+    if (startupCatalogToken) {
       cachedAllModels = await fetchKiloModels({
-        token: storedCredentials.access,
+        token: startupCatalogToken,
         organizationId: startupOrganizationId,
       });
       freeModels = cachedAllModels.length > 0 ? cachedAllModels : [];

--- a/test/kilo.test.ts
+++ b/test/kilo.test.ts
@@ -108,3 +108,28 @@ test("loads the organization catalog with stored OAuth credentials", async () =>
     }),
   );
 });
+
+test("loads the organization catalog with KILO_API_KEY", async () => {
+  const agentDirectory = mkdtempSync(join(tmpdir(), "kilo-pi-provider-test-"));
+  temporaryDirectories.push(agentDirectory);
+  vi.stubEnv("PI_CODING_AGENT_DIR", agentDirectory);
+  vi.stubEnv("KILO_API_KEY", "environment-api-key");
+  vi.stubEnv("KILO_ORG_ID", "organization-id");
+  vi.stubEnv("KILOCODE_ORGANIZATION_ID", "");
+
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
+  vi.stubGlobal("fetch", fetchMock);
+
+  await kiloExtension({ registerProvider: vi.fn(), on: vi.fn() } as never);
+
+  expect(fetchMock).toHaveBeenCalledOnce();
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://api.kilo.ai/api/organizations/organization-id/models",
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer environment-api-key",
+        "X-KiloCode-OrganizationId": "organization-id",
+      }),
+    }),
+  );
+});


### PR DESCRIPTION
Use KILO_API_KEY for startup catalogue discovery when stored OAuth credentials are unavailable. This lets API-key users load their authenticated personal or organization model catalogue rather than the anonymous free-model list.

Keep stored OAuth credentials as the preferred source when both are configured. Cover the organization API-key path with a mocked regression test.