### PR TITLE
feat: allow disabling Kilo custom footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ This opens your browser for device authorization. When your account belongs to o
 
 You can also set `KILO_API_KEY` directly instead of using the login flow. Set `KILO_ORG_ID` or `KILOCODE_ORGANIZATION_ID` to bill and filter models for an organization account.
 
+### Footer
+
+Kilo replaces Pi's footer by default to show usage and credits. To keep another extension's custom footer, disable Kilo's footer:
+
+```bash
+KILO_CUSTOM_FOOTER=0 pi
+```
+
+Kilo credits remain available as the `kilo-credits` footer status.
+
 ## Development
 
 Install dependencies and run the tests:

--- a/kilo.ts
+++ b/kilo.ts
@@ -40,6 +40,11 @@ function getEnvOrganizationId(): string | undefined {
   return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
 }
 
+export function usesCustomFooter(): boolean {
+  const value = process.env.KILO_CUSTOM_FOOTER?.trim().toLowerCase();
+  return !["0", "false", "no"].includes(value ?? "");
+}
+
 function getAgentDir(): string {
   return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 }
@@ -826,9 +831,11 @@ export default async function (pi: ExtensionAPI) {
     };
   });
 
-  // Use custom footer to show credits inline with token stats
-  pi.on("session_start", async (_event, ctx) => {
-    ctx.ui.setFooter((tui, theme, footerData) => {
+  // Use custom footer to show credits inline with token stats.
+  // Disable it with KILO_CUSTOM_FOOTER=0 to allow another extension's footer.
+  if (usesCustomFooter()) {
+    pi.on("session_start", async (_event, ctx) => {
+      ctx.ui.setFooter((tui, theme, footerData) => {
       const unsubBranch = footerData.onBranchChange(() => tui.requestRender());
 
       const formatTokens = (count: number): string => {
@@ -970,6 +977,7 @@ export default async function (pi: ExtensionAPI) {
           return [theme.fg("dim", pwd), dimStatsLeft + dimRemainder];
         },
       };
+      });
     });
-  });
+  }
 }

--- a/test/kilo.test.ts
+++ b/test/kilo.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
-import kiloExtension from "../kilo.ts";
+import kiloExtension, { usesCustomFooter } from "../kilo.ts";
 
 const temporaryDirectories: string[] = [];
 
@@ -36,6 +36,95 @@ const catalogResponse = () =>
     }),
     { status: 200, headers: { "Content-Type": "application/json" } },
   );
+
+test.each([
+  [undefined, true],
+  ["1", true],
+  ["true", true],
+  ["unexpected", true],
+  ["0", false],
+  ["false", false],
+  ["FALSE", false],
+  [" no ", false],
+])("usesCustomFooter returns %s for KILO_CUSTOM_FOOTER=%s", (value, expected) => {
+  if (value === undefined) {
+    vi.stubEnv("KILO_CUSTOM_FOOTER", "");
+  } else {
+    vi.stubEnv("KILO_CUSTOM_FOOTER", value);
+  }
+
+  expect(usesCustomFooter()).toBe(expected);
+});
+
+async function customFooterWasInstalled(customFooter: string): Promise<boolean> {
+  const agentDirectory = mkdtempSync(join(tmpdir(), "kilo-pi-provider-test-"));
+  temporaryDirectories.push(agentDirectory);
+  vi.stubEnv("PI_CODING_AGENT_DIR", agentDirectory);
+  vi.stubEnv("KILO_CUSTOM_FOOTER", customFooter);
+  vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(catalogResponse()));
+
+  const on = vi.fn();
+  const setFooter = vi.fn();
+  await kiloExtension({ registerProvider: vi.fn(), on } as never);
+
+  const sessionStartHandlers = on.mock.calls
+    .filter(([event]) => event === "session_start")
+    .map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
+  const context = { hasUI: true, ui: { setFooter, setStatus: vi.fn() } };
+  await Promise.all(sessionStartHandlers.map((handler) => handler({}, context)));
+
+  return setFooter.mock.calls.length > 0;
+}
+
+test("does not install the custom footer when disabled", async () => {
+  await expect(customFooterWasInstalled("0")).resolves.toBe(false);
+});
+
+test("installs the custom footer by default", async () => {
+  await expect(customFooterWasInstalled("")).resolves.toBe(true);
+});
+
+test("exposes Kilo credits when the custom footer is disabled", async () => {
+  const agentDirectory = mkdtempSync(join(tmpdir(), "kilo-pi-provider-test-"));
+  temporaryDirectories.push(agentDirectory);
+  writeFileSync(
+    join(agentDirectory, "auth.json"),
+    JSON.stringify({
+      kilo: { type: "oauth", access: "stored-access-token" },
+    }),
+  );
+  vi.stubEnv("PI_CODING_AGENT_DIR", agentDirectory);
+  vi.stubEnv("KILO_CUSTOM_FOOTER", "0");
+
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce(catalogResponse())
+    .mockResolvedValueOnce(catalogResponse())
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ balance: 12.34 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+
+  const on = vi.fn();
+  const setStatus = vi.fn();
+  await kiloExtension({ registerProvider: vi.fn(), on } as never);
+
+  const sessionStartHandlers = on.mock.calls
+    .filter(([event]) => event === "session_start")
+    .map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
+  const context = {
+    hasUI: true,
+    ui: { setFooter: vi.fn(), setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
+    modelRegistry: { registerProvider: vi.fn() },
+  };
+  await Promise.all(sessionStartHandlers.map((handler) => handler({}, context)));
+
+  expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
+  expect(context.ui.setFooter).not.toHaveBeenCalled();
+});
 
 test("registers anonymous free models from the Kilo catalog", async () => {
   const agentDirectory = mkdtempSync(join(tmpdir(), "kilo-pi-provider-test-"));


### PR DESCRIPTION
Extension replaces Pi's footer by default to show usage totals and kilo credits -- this means that it overrides *any* custom footer, too.  This PR introduces opt-out logic with an env variable `KILO_CUSTOM_FOOTER` that can unset kilo's footer, while still exposing `kilo-credits` to be presented optionally.