### PR TITLE
refactor: extract Kilo auth and profile API modules

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,11 @@
+export const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
+export const KILO_PROFILE_ENDPOINT = `${KILO_API_BASE}/api/profile`;
+export const KILO_ORG_HEADER = "X-KiloCode-OrganizationId";
+
+export function withOrganizationHeader(
+  headers: Record<string, string>,
+  organizationId?: string,
+): Record<string, string> {
+  if (!organizationId) return headers;
+  return { ...headers, [KILO_ORG_HEADER]: organizationId };
+}

--- a/api.ts
+++ b/api.ts
@@ -9,3 +9,31 @@ export function withOrganizationHeader(
   if (!organizationId) return headers;
   return { ...headers, [KILO_ORG_HEADER]: organizationId };
 }
+
+export interface KiloOrganization {
+  id: string;
+  name: string;
+  role?: string;
+}
+
+export interface KiloProfile {
+  user?: { email?: string; name?: string };
+  email?: string;
+  name?: string;
+  organizations?: KiloOrganization[];
+}
+
+export async function fetchKiloProfile(token: string): Promise<KiloProfile> {
+  const response = await fetch(KILO_PROFILE_ENDPOINT, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Kilo profile: ${response.status}`);
+  }
+
+  return (await response.json()) as KiloProfile;
+}

--- a/api.ts
+++ b/api.ts
@@ -1,5 +1,5 @@
 export const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
-export const KILO_PROFILE_ENDPOINT = `${KILO_API_BASE}/api/profile`;
+const KILO_PROFILE_ENDPOINT = `${KILO_API_BASE}/api/profile`;
 export const KILO_ORG_HEADER = "X-KiloCode-OrganizationId";
 
 export function withOrganizationHeader(
@@ -38,7 +38,7 @@ export async function fetchKiloProfile(token: string): Promise<KiloProfile> {
   return (await response.json()) as KiloProfile;
 }
 
-export interface KiloBalance {
+interface KiloBalance {
   balance?: number;
 }
 

--- a/api.ts
+++ b/api.ts
@@ -37,3 +37,33 @@ export async function fetchKiloProfile(token: string): Promise<KiloProfile> {
 
   return (await response.json()) as KiloProfile;
 }
+
+export interface KiloBalance {
+  balance?: number;
+}
+
+export async function fetchKiloBalance(
+  token: string,
+  organizationId?: string,
+): Promise<number | null> {
+  try {
+    const response = await fetch(`${KILO_PROFILE_ENDPOINT}/balance`, {
+      headers: withOrganizationHeader(
+        {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        organizationId,
+      ),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as KiloBalance;
+    return data.balance ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/auth.ts
+++ b/auth.ts
@@ -5,7 +5,7 @@ import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-a
 import { KILO_API_BASE, fetchKiloProfile, type KiloProfile } from "./api.ts";
 
 const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
-export const POLL_INTERVAL_MS = 3000;
+const POLL_INTERVAL_MS = 3000;
 const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 
 export function getEnvOrganizationId(): string | undefined {

--- a/auth.ts
+++ b/auth.ts
@@ -2,7 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { fetchKiloProfile, type KiloProfile } from "./api.ts";
+import { KILO_API_BASE, fetchKiloProfile, type KiloProfile } from "./api.ts";
+
+const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
+export const POLL_INTERVAL_MS = 3000;
 
 export function getEnvOrganizationId(): string | undefined {
   return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
@@ -34,6 +37,70 @@ export function getCredentialOrganizationId(credentials?: OAuthCredentials): str
 
 export function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
   return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
+}
+
+interface DeviceAuthResponse {
+  code: string;
+  verificationUrl: string;
+  expiresIn: number;
+}
+
+interface DeviceAuthPollResponse {
+  status: "pending" | "approved" | "denied" | "expired";
+  token?: string;
+  userEmail?: string;
+}
+
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Login cancelled"));
+      return;
+    }
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(new Error("Login cancelled"));
+      },
+      { once: true },
+    );
+  });
+}
+
+export async function initiateDeviceAuth(): Promise<DeviceAuthResponse> {
+  const response = await fetch(KILO_DEVICE_AUTH_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new Error(
+        "Too many pending authorization requests. Please try again later.",
+      );
+    }
+    throw new Error(
+      `Failed to initiate device authorization: ${response.status}`,
+    );
+  }
+
+  return (await response.json()) as DeviceAuthResponse;
+}
+
+export async function pollDeviceAuth(code: string): Promise<DeviceAuthPollResponse> {
+  const response = await fetch(`${KILO_DEVICE_AUTH_ENDPOINT}/${code}`);
+
+  if (response.status === 202) return { status: "pending" };
+  if (response.status === 403) return { status: "denied" };
+  if (response.status === 410) return { status: "expired" };
+
+  if (!response.ok) {
+    throw new Error(`Failed to poll device authorization: ${response.status}`);
+  }
+
+  return (await response.json()) as DeviceAuthPollResponse;
 }
 
 export async function selectKiloOrganization(

--- a/auth.ts
+++ b/auth.ts
@@ -6,6 +6,7 @@ import { KILO_API_BASE, fetchKiloProfile, type KiloProfile } from "./api.ts";
 
 const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
 export const POLL_INTERVAL_MS = 3000;
+const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 
 export function getEnvOrganizationId(): string | undefined {
   return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
@@ -101,6 +102,61 @@ export async function pollDeviceAuth(code: string): Promise<DeviceAuthPollRespon
   }
 
   return (await response.json()) as DeviceAuthPollResponse;
+}
+
+export async function loginKilo(
+  callbacks: OAuthLoginCallbacks,
+): Promise<OAuthCredentials> {
+  callbacks.onProgress?.("Initiating device authorization...");
+  const authData = await initiateDeviceAuth();
+  const { code, verificationUrl, expiresIn } = authData;
+
+  callbacks.onAuth({
+    url: verificationUrl,
+    instructions: `Enter code: ${code}`,
+  });
+
+  callbacks.onProgress?.("Waiting for browser authorization...");
+
+  const deadline = Date.now() + expiresIn * 1000;
+  while (Date.now() < deadline) {
+    if (callbacks.signal?.aborted) {
+      throw new Error("Login cancelled");
+    }
+
+    await abortableSleep(POLL_INTERVAL_MS, callbacks.signal);
+
+    const result = await pollDeviceAuth(code);
+
+    if (result.status === "approved") {
+      if (!result.token) {
+        throw new Error("Authorization approved but no token received");
+      }
+      callbacks.onProgress?.("Login successful!");
+      const organizationId = await selectKiloOrganization(result.token, callbacks);
+      return {
+        refresh: result.token,
+        access: result.token,
+        expires: Date.now() + TOKEN_EXPIRATION_MS,
+        ...(organizationId ? { accountId: organizationId } : {}),
+      };
+    }
+
+    if (result.status === "denied") {
+      throw new Error("Authorization denied by user.");
+    }
+
+    if (result.status === "expired") {
+      throw new Error("Authorization code expired. Please try again.");
+    }
+
+    const remaining = Math.ceil((deadline - Date.now()) / 1000);
+    callbacks.onProgress?.(
+      `Waiting for browser authorization... (${remaining}s remaining)`,
+    );
+  }
+
+  throw new Error("Authentication timed out. Please try again.");
 }
 
 export async function selectKiloOrganization(

--- a/auth.ts
+++ b/auth.ts
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { fetchKiloProfile, type KiloProfile } from "./api.ts";
 
 export function getEnvOrganizationId(): string | undefined {
   return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
@@ -33,4 +34,44 @@ export function getCredentialOrganizationId(credentials?: OAuthCredentials): str
 
 export function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
   return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
+}
+
+export async function selectKiloOrganization(
+  token: string,
+  callbacks: OAuthLoginCallbacks,
+): Promise<string | undefined> {
+  let profile: KiloProfile;
+  try {
+    callbacks.onProgress?.("Fetching Kilo profile...");
+    profile = await fetchKiloProfile(token);
+  } catch (error) {
+    console.warn(
+      "[kilo] Failed to fetch profile for organization selection:",
+      error instanceof Error ? error.message : error,
+    );
+    return getEnvOrganizationId();
+  }
+
+  const organizations = profile.organizations ?? [];
+  const envOrganizationId = getEnvOrganizationId();
+  if (envOrganizationId && organizations.some((org) => org.id === envOrganizationId)) {
+    return envOrganizationId;
+  }
+  if (!callbacks.onSelect || organizations.length === 0) {
+    return envOrganizationId;
+  }
+
+  const selected = await callbacks.onSelect({
+    message: "Select Kilo account",
+    options: [
+      { id: "personal", label: "Personal Account" },
+      ...organizations.map((org) => ({
+        id: org.id,
+        label: `${org.name}${org.role ? ` (${org.role})` : ""}`,
+      })),
+    ],
+  });
+
+  if (!selected || selected === "personal") return undefined;
+  return selected;
 }

--- a/auth.ts
+++ b/auth.ts
@@ -104,6 +104,17 @@ export async function pollDeviceAuth(code: string): Promise<DeviceAuthPollRespon
   return (await response.json()) as DeviceAuthPollResponse;
 }
 
+export async function refreshKiloToken(
+  credentials: OAuthCredentials,
+): Promise<OAuthCredentials> {
+  if (credentials.expires > Date.now()) {
+    return credentials;
+  }
+  throw new Error(
+    "Kilo token expired. Please run /login kilo to re-authenticate.",
+  );
+}
+
 export async function loginKilo(
   callbacks: OAuthLoginCallbacks,
 ): Promise<OAuthCredentials> {

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
+
+export function getEnvOrganizationId(): string | undefined {
+  return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
+}
+
+export function getAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+export function readStoredKiloCredentials(): OAuthCredentials | undefined {
+  try {
+    const authPath = join(getAgentDir(), "auth.json");
+    if (!existsSync(authPath)) return undefined;
+    const auth = JSON.parse(readFileSync(authPath, "utf8")) as {
+      kilo?: { type?: string } & OAuthCredentials;
+    };
+    const cred = auth.kilo;
+    if (cred?.type !== "oauth" || !cred.access) return undefined;
+    return cred;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getCredentialOrganizationId(credentials?: OAuthCredentials): string | undefined {
+  const accountId = credentials?.accountId;
+  return typeof accountId === "string" && accountId.trim() ? accountId : undefined;
+}
+
+export function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
+  return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
+}

--- a/kilo.ts
+++ b/kilo.ts
@@ -20,12 +20,17 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import {
+  KILO_API_BASE,
+  KILO_ORG_HEADER,
+  KILO_PROFILE_ENDPOINT,
+  withOrganizationHeader,
+} from "./api.ts";
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 const KILO_OPENROUTER_BASE = `${KILO_API_BASE}/api/openrouter`;
 const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
@@ -33,8 +38,6 @@ const POLL_INTERVAL_MS = 3000;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 const KILO_TOS_URL = "https://kilo.ai/terms";
-const KILO_PROFILE_ENDPOINT = `${KILO_API_BASE}/api/profile`;
-const KILO_ORG_HEADER = "X-KiloCode-OrganizationId";
 
 function getEnvOrganizationId(): string | undefined {
   return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
@@ -71,14 +74,6 @@ function getCredentialOrganizationId(credentials?: OAuthCredentials): string | u
 
 function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
   return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
-}
-
-function withOrganizationHeader(
-  headers: Record<string, string>,
-  organizationId?: string,
-): Record<string, string> {
-  if (!organizationId) return headers;
-  return { ...headers, [KILO_ORG_HEADER]: organizationId };
 }
 
 // =============================================================================

--- a/kilo.ts
+++ b/kilo.ts
@@ -9,9 +9,6 @@
  *   # Then /login kilo, or set KILO_API_KEY=...
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type {
   Api,
   Model,
@@ -28,6 +25,11 @@ import {
   type KiloProfile,
   withOrganizationHeader,
 } from "./api.ts";
+import {
+  getEffectiveOrganizationId,
+  getEnvOrganizationId,
+  readStoredKiloCredentials,
+} from "./auth.ts";
 
 // =============================================================================
 // Constants
@@ -41,41 +43,9 @@ const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 const KILO_TOS_URL = "https://kilo.ai/terms";
 
-function getEnvOrganizationId(): string | undefined {
-  return process.env.KILO_ORG_ID || process.env.KILOCODE_ORGANIZATION_ID;
-}
-
 export function usesCustomFooter(): boolean {
   const value = process.env.KILO_CUSTOM_FOOTER?.trim().toLowerCase();
   return !["0", "false", "no"].includes(value ?? "");
-}
-
-function getAgentDir(): string {
-  return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
-}
-
-function readStoredKiloCredentials(): OAuthCredentials | undefined {
-  try {
-    const authPath = join(getAgentDir(), "auth.json");
-    if (!existsSync(authPath)) return undefined;
-    const auth = JSON.parse(readFileSync(authPath, "utf8")) as {
-      kilo?: { type?: string } & OAuthCredentials;
-    };
-    const cred = auth.kilo;
-    if (cred?.type !== "oauth" || !cred.access) return undefined;
-    return cred;
-  } catch {
-    return undefined;
-  }
-}
-
-function getCredentialOrganizationId(credentials?: OAuthCredentials): string | undefined {
-  const accountId = credentials?.accountId;
-  return typeof accountId === "string" && accountId.trim() ? accountId : undefined;
-}
-
-function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
-  return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
 }
 
 // =============================================================================

--- a/kilo.ts
+++ b/kilo.ts
@@ -19,16 +19,15 @@ import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-codin
 import { visibleWidth } from "@earendil-works/pi-tui";
 import {
   fetchKiloBalance,
-  fetchKiloProfile,
   KILO_API_BASE,
   KILO_ORG_HEADER,
-  type KiloProfile,
   withOrganizationHeader,
 } from "./api.ts";
 import {
   getEffectiveOrganizationId,
   getEnvOrganizationId,
   readStoredKiloCredentials,
+  selectKiloOrganization,
 } from "./auth.ts";
 
 // =============================================================================
@@ -51,46 +50,6 @@ export function usesCustomFooter(): boolean {
 // =============================================================================
 // Profile and Balance Fetching
 // =============================================================================
-
-async function selectKiloOrganization(
-  token: string,
-  callbacks: OAuthLoginCallbacks,
-): Promise<string | undefined> {
-  let profile: KiloProfile;
-  try {
-    callbacks.onProgress?.("Fetching Kilo profile...");
-    profile = await fetchKiloProfile(token);
-  } catch (error) {
-    console.warn(
-      "[kilo] Failed to fetch profile for organization selection:",
-      error instanceof Error ? error.message : error,
-    );
-    return getEnvOrganizationId();
-  }
-
-  const organizations = profile.organizations ?? [];
-  const envOrganizationId = getEnvOrganizationId();
-  if (envOrganizationId && organizations.some((org) => org.id === envOrganizationId)) {
-    return envOrganizationId;
-  }
-  if (!callbacks.onSelect || organizations.length === 0) {
-    return envOrganizationId;
-  }
-
-  const selected = await callbacks.onSelect({
-    message: "Select Kilo account",
-    options: [
-      { id: "personal", label: "Personal Account" },
-      ...organizations.map((org) => ({
-        id: org.id,
-        label: `${org.name}${org.role ? ` (${org.role})` : ""}`,
-      })),
-    ],
-  });
-
-  if (!selected || selected === "personal") return undefined;
-  return selected;
-}
 
 function formatCredits(balance: number): string {
   if (balance >= 1000) {

--- a/kilo.ts
+++ b/kilo.ts
@@ -45,10 +45,6 @@ export function usesCustomFooter(): boolean {
   return !["0", "false", "no"].includes(value ?? "");
 }
 
-// =============================================================================
-// Profile and Balance Fetching
-// =============================================================================
-
 function formatCredits(balance: number): string {
   if (balance >= 1000) {
     return `$${(balance / 1000).toFixed(1)}k`;
@@ -56,10 +52,6 @@ function formatCredits(balance: number): string {
     return `$${balance.toFixed(2)}`;
   }
 }
-
-// =============================================================================
-// Device Authorization Flow
-// =============================================================================
 
 // =============================================================================
 // Dynamic Model Loading

--- a/kilo.ts
+++ b/kilo.ts
@@ -24,8 +24,12 @@ import {
   withOrganizationHeader,
 } from "./api.ts";
 import {
+  abortableSleep,
   getEffectiveOrganizationId,
   getEnvOrganizationId,
+  initiateDeviceAuth,
+  pollDeviceAuth,
+  POLL_INTERVAL_MS,
   readStoredKiloCredentials,
   selectKiloOrganization,
 } from "./auth.ts";
@@ -36,8 +40,6 @@ import {
 
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 const KILO_OPENROUTER_BASE = `${KILO_API_BASE}/api/openrouter`;
-const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
-const POLL_INTERVAL_MS = 3000;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 const KILO_TOS_URL = "https://kilo.ai/terms";
@@ -62,70 +64,6 @@ function formatCredits(balance: number): string {
 // =============================================================================
 // Device Authorization Flow
 // =============================================================================
-
-interface DeviceAuthResponse {
-  code: string;
-  verificationUrl: string;
-  expiresIn: number;
-}
-
-interface DeviceAuthPollResponse {
-  status: "pending" | "approved" | "denied" | "expired";
-  token?: string;
-  userEmail?: string;
-}
-
-function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(new Error("Login cancelled"));
-      return;
-    }
-    const timeout = setTimeout(resolve, ms);
-    signal?.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeout);
-        reject(new Error("Login cancelled"));
-      },
-      { once: true },
-    );
-  });
-}
-
-async function initiateDeviceAuth(): Promise<DeviceAuthResponse> {
-  const response = await fetch(KILO_DEVICE_AUTH_ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-  });
-
-  if (!response.ok) {
-    if (response.status === 429) {
-      throw new Error(
-        "Too many pending authorization requests. Please try again later.",
-      );
-    }
-    throw new Error(
-      `Failed to initiate device authorization: ${response.status}`,
-    );
-  }
-
-  return (await response.json()) as DeviceAuthResponse;
-}
-
-async function pollDeviceAuth(code: string): Promise<DeviceAuthPollResponse> {
-  const response = await fetch(`${KILO_DEVICE_AUTH_ENDPOINT}/${code}`);
-
-  if (response.status === 202) return { status: "pending" };
-  if (response.status === 403) return { status: "denied" };
-  if (response.status === 410) return { status: "expired" };
-
-  if (!response.ok) {
-    throw new Error(`Failed to poll device authorization: ${response.status}`);
-  }
-
-  return (await response.json()) as DeviceAuthPollResponse;
-}
 
 async function loginKilo(
   callbacks: OAuthLoginCallbacks,

--- a/kilo.ts
+++ b/kilo.ts
@@ -21,9 +21,11 @@ import type {
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import {
+  fetchKiloProfile,
   KILO_API_BASE,
   KILO_ORG_HEADER,
   KILO_PROFILE_ENDPOINT,
+  type KiloProfile,
   withOrganizationHeader,
 } from "./api.ts";
 
@@ -80,36 +82,8 @@ function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | un
 // Profile and Balance Fetching
 // =============================================================================
 
-interface KiloOrganization {
-  id: string;
-  name: string;
-  role?: string;
-}
-
-interface KiloProfile {
-  user?: { email?: string; name?: string };
-  email?: string;
-  name?: string;
-  organizations?: KiloOrganization[];
-}
-
 interface KiloBalance {
   balance?: number;
-}
-
-async function fetchKiloProfile(token: string): Promise<KiloProfile> {
-  const response = await fetch(KILO_PROFILE_ENDPOINT, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch Kilo profile: ${response.status}`);
-  }
-
-  return (await response.json()) as KiloProfile;
 }
 
 async function selectKiloOrganization(

--- a/kilo.ts
+++ b/kilo.ts
@@ -21,10 +21,10 @@ import type {
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import {
+  fetchKiloBalance,
   fetchKiloProfile,
   KILO_API_BASE,
   KILO_ORG_HEADER,
-  KILO_PROFILE_ENDPOINT,
   type KiloProfile,
   withOrganizationHeader,
 } from "./api.ts";
@@ -82,10 +82,6 @@ function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | un
 // Profile and Balance Fetching
 // =============================================================================
 
-interface KiloBalance {
-  balance?: number;
-}
-
 async function selectKiloOrganization(
   token: string,
   callbacks: OAuthLoginCallbacks,
@@ -124,32 +120,6 @@ async function selectKiloOrganization(
 
   if (!selected || selected === "personal") return undefined;
   return selected;
-}
-
-async function fetchKiloBalance(
-  token: string,
-  organizationId?: string,
-): Promise<number | null> {
-  try {
-    const response = await fetch(`${KILO_PROFILE_ENDPOINT}/balance`, {
-      headers: withOrganizationHeader(
-        {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        organizationId,
-      ),
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = (await response.json()) as KiloBalance;
-    return data.balance ?? null;
-  } catch {
-    return null;
-  }
 }
 
 function formatCredits(balance: number): string {

--- a/kilo.ts
+++ b/kilo.ts
@@ -24,14 +24,10 @@ import {
   withOrganizationHeader,
 } from "./api.ts";
 import {
-  abortableSleep,
   getEffectiveOrganizationId,
   getEnvOrganizationId,
-  initiateDeviceAuth,
-  pollDeviceAuth,
-  POLL_INTERVAL_MS,
+  loginKilo,
   readStoredKiloCredentials,
-  selectKiloOrganization,
 } from "./auth.ts";
 
 // =============================================================================
@@ -41,7 +37,6 @@ import {
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 const KILO_OPENROUTER_BASE = `${KILO_API_BASE}/api/openrouter`;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
-const TOKEN_EXPIRATION_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
 const KILO_TOS_URL = "https://kilo.ai/terms";
 
 export function usesCustomFooter(): boolean {
@@ -64,61 +59,6 @@ function formatCredits(balance: number): string {
 // =============================================================================
 // Device Authorization Flow
 // =============================================================================
-
-async function loginKilo(
-  callbacks: OAuthLoginCallbacks,
-): Promise<OAuthCredentials> {
-  callbacks.onProgress?.("Initiating device authorization...");
-  const authData = await initiateDeviceAuth();
-  const { code, verificationUrl, expiresIn } = authData;
-
-  callbacks.onAuth({
-    url: verificationUrl,
-    instructions: `Enter code: ${code}`,
-  });
-
-  callbacks.onProgress?.("Waiting for browser authorization...");
-
-  const deadline = Date.now() + expiresIn * 1000;
-  while (Date.now() < deadline) {
-    if (callbacks.signal?.aborted) {
-      throw new Error("Login cancelled");
-    }
-
-    await abortableSleep(POLL_INTERVAL_MS, callbacks.signal);
-
-    const result = await pollDeviceAuth(code);
-
-    if (result.status === "approved") {
-      if (!result.token) {
-        throw new Error("Authorization approved but no token received");
-      }
-      callbacks.onProgress?.("Login successful!");
-      const organizationId = await selectKiloOrganization(result.token, callbacks);
-      return {
-        refresh: result.token,
-        access: result.token,
-        expires: Date.now() + TOKEN_EXPIRATION_MS,
-        ...(organizationId ? { accountId: organizationId } : {}),
-      };
-    }
-
-    if (result.status === "denied") {
-      throw new Error("Authorization denied by user.");
-    }
-
-    if (result.status === "expired") {
-      throw new Error("Authorization code expired. Please try again.");
-    }
-
-    const remaining = Math.ceil((deadline - Date.now()) / 1000);
-    callbacks.onProgress?.(
-      `Waiting for browser authorization... (${remaining}s remaining)`,
-    );
-  }
-
-  throw new Error("Authentication timed out. Please try again.");
-}
 
 async function refreshKiloToken(
   credentials: OAuthCredentials,

--- a/kilo.ts
+++ b/kilo.ts
@@ -28,6 +28,7 @@ import {
   getEnvOrganizationId,
   loginKilo,
   readStoredKiloCredentials,
+  refreshKiloToken,
 } from "./auth.ts";
 
 // =============================================================================
@@ -59,17 +60,6 @@ function formatCredits(balance: number): string {
 // =============================================================================
 // Device Authorization Flow
 // =============================================================================
-
-async function refreshKiloToken(
-  credentials: OAuthCredentials,
-): Promise<OAuthCredentials> {
-  if (credentials.expires > Date.now()) {
-    return credentials;
-  }
-  throw new Error(
-    "Kilo token expired. Please run /login kilo to re-authenticate.",
-  );
-}
 
 // =============================================================================
 // Dynamic Model Loading

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { KILO_ORG_HEADER, withOrganizationHeader } from "../api.ts";
+
+describe("withOrganizationHeader", () => {
+  test("returns the original object when there is no organization", () => {
+    const headers = { Authorization: "Bearer token" };
+
+    expect(withOrganizationHeader(headers)).toBe(headers);
+  });
+
+  test("adds the organization header with the exact spelling and value", () => {
+    expect(withOrganizationHeader({}, "organization-id")).toEqual({
+      [KILO_ORG_HEADER]: "organization-id",
+    });
+    expect(KILO_ORG_HEADER).toBe("X-KiloCode-OrganizationId");
+  });
+
+  test("preserves existing headers", () => {
+    expect(
+      withOrganizationHeader(
+        { Authorization: "Bearer token", "Content-Type": "application/json" },
+        "organization-id",
+      ),
+    ).toEqual({
+      Authorization: "Bearer token",
+      "Content-Type": "application/json",
+      "X-KiloCode-OrganizationId": "organization-id",
+    });
+  });
+
+  test("does not mutate the input when adding an organization", () => {
+    const headers = { Authorization: "Bearer token" };
+
+    withOrganizationHeader(headers, "organization-id");
+
+    expect(headers).toEqual({ Authorization: "Bearer token" });
+  });
+});

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  KILO_API_BASE,
   KILO_ORG_HEADER,
   fetchKiloBalance,
   fetchKiloProfile,
@@ -56,7 +57,7 @@ describe("fetchKiloProfile", () => {
 
     await fetchKiloProfile("access-token");
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile", {
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/profile`, {
       headers: {
         Authorization: "Bearer access-token",
         "Content-Type": "application/json",
@@ -107,7 +108,7 @@ describe("fetchKiloBalance", () => {
 
     await fetchKiloBalance("access-token");
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile/balance", {
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/profile/balance`, {
       headers: {
         Authorization: "Bearer access-token",
         "Content-Type": "application/json",
@@ -123,7 +124,7 @@ describe("fetchKiloBalance", () => {
 
     await fetchKiloBalance("access-token", "organization-id");
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile/balance", {
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/profile/balance`, {
       headers: {
         Authorization: "Bearer access-token",
         "Content-Type": "application/json",
@@ -146,6 +147,17 @@ describe("fetchKiloBalance", () => {
         "Content-Type": "application/json",
       },
     });
+  });
+
+  test("preserves a zero balance on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ balance: 0 }), { status: 200 }),
+      ),
+    );
+
+    await expect(fetchKiloBalance("access-token")).resolves.toBe(0);
   });
 
   test("returns the balance on success", async () => {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { KILO_ORG_HEADER, fetchKiloProfile, withOrganizationHeader } from "../api.ts";
+import {
+  KILO_ORG_HEADER,
+  fetchKiloBalance,
+  fetchKiloProfile,
+  withOrganizationHeader,
+} from "../api.ts";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -90,5 +95,91 @@ describe("fetchKiloProfile", () => {
     vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(error));
 
     await expect(fetchKiloProfile("access-token")).rejects.toBe(error);
+  });
+});
+
+describe("fetchKiloBalance", () => {
+  test("fetches the balance URL with bearer and content-type headers", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKiloBalance("access-token");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile/balance", {
+      headers: {
+        Authorization: "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test("includes the organization header when supplied", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKiloBalance("access-token", "organization-id");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile/balance", {
+      headers: {
+        Authorization: "Bearer access-token",
+        "Content-Type": "application/json",
+        "X-KiloCode-OrganizationId": "organization-id",
+      },
+    });
+  });
+
+  test("omits the organization header when absent", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKiloBalance("access-token");
+
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual({
+      headers: {
+        Authorization: "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test("returns the balance on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }),
+      ),
+    );
+
+    await expect(fetchKiloBalance("access-token")).resolves.toBe(12.34);
+  });
+
+  test("returns null when the successful response has no balance", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 })),
+    );
+
+    await expect(fetchKiloBalance("access-token")).resolves.toBeNull();
+  });
+
+  test("returns null for a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 })),
+    );
+
+    await expect(fetchKiloBalance("access-token")).resolves.toBeNull();
+  });
+
+  test("returns null when fetch rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(new Error("network failure")));
+
+    await expect(fetchKiloBalance("access-token")).resolves.toBeNull();
   });
 });

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, test } from "vitest";
-import { KILO_ORG_HEADER, withOrganizationHeader } from "../api.ts";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { KILO_ORG_HEADER, fetchKiloProfile, withOrganizationHeader } from "../api.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
 
 describe("withOrganizationHeader", () => {
   test("returns the original object when there is no organization", () => {
@@ -34,5 +39,56 @@ describe("withOrganizationHeader", () => {
     withOrganizationHeader(headers, "organization-id");
 
     expect(headers).toEqual({ Authorization: "Bearer token" });
+  });
+});
+
+describe("fetchKiloProfile", () => {
+  test("fetches the default profile URL with bearer and content-type headers", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ email: "user@example.com" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchKiloProfile("access-token");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile", {
+      headers: {
+        Authorization: "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test("returns the parsed profile on success", async () => {
+    const profile = {
+      user: { email: "user@example.com", name: "User" },
+      organizations: [{ id: "org-id", name: "Organization", role: "member" }],
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify(profile), { status: 200 }),
+      ),
+    );
+
+    await expect(fetchKiloProfile("access-token")).resolves.toEqual(profile);
+  });
+
+  test("throws the exact error for a non-OK response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 })),
+    );
+
+    await expect(fetchKiloProfile("access-token")).rejects.toThrow(
+      "Failed to fetch Kilo profile: 503",
+    );
+  });
+
+  test("propagates a fetch rejection unchanged", async () => {
+    const error = new Error("network failure");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(error));
+
+    await expect(fetchKiloProfile("access-token")).rejects.toBe(error);
   });
 });

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -9,6 +9,7 @@ import {
   initiateDeviceAuth,
   loginKilo,
   pollDeviceAuth,
+  refreshKiloToken,
   selectKiloOrganization,
   getEffectiveOrganizationId,
   getEnvOrganizationId,
@@ -24,6 +25,36 @@ afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+describe("refreshKiloToken", () => {
+  test("returns the exact same credentials object when not expired", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const credentials = { type: "oauth", access: "token", expires: 1001 } as never;
+
+    await expect(refreshKiloToken(credentials)).resolves.toBe(credentials);
+  });
+
+  test("throws the exact error when expired", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const credentials = { type: "oauth", access: "token", expires: 999 } as never;
+
+    await expect(refreshKiloToken(credentials)).rejects.toThrow(
+      "Kilo token expired. Please run /login kilo to re-authenticate.",
+    );
+  });
+
+  test("treats expiration equal to Date.now as expired", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const credentials = { type: "oauth", access: "token", expires: 1000 } as never;
+
+    await expect(refreshKiloToken(credentials)).rejects.toThrow(
+      "Kilo token expired. Please run /login kilo to re-authenticate.",
+    );
+  });
 });
 
 describe("loginKilo", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -3,8 +3,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  abortableSleep,
   getAgentDir,
   getCredentialOrganizationId,
+  initiateDeviceAuth,
+  pollDeviceAuth,
   selectKiloOrganization,
   getEffectiveOrganizationId,
   getEnvOrganizationId,
@@ -14,11 +17,117 @@ import {
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+describe("device authorization", () => {
+  test("initiates device authorization with the exact POST request", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 60 }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await initiateDeviceAuth();
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/device-auth/codes", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  test("returns parsed device authorization success", async () => {
+    const response = { code: "code", verificationUrl: "url", expiresIn: 60 };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(new Response(JSON.stringify(response), { status: 200 })),
+    );
+
+    await expect(initiateDeviceAuth()).resolves.toEqual(response);
+  });
+
+  test("throws the exact rate-limit message", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 429 })));
+
+    await expect(initiateDeviceAuth()).rejects.toThrow(
+      "Too many pending authorization requests. Please try again later.",
+    );
+  });
+
+  test("throws the exact generic initiation status message", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 500 })));
+
+    await expect(initiateDeviceAuth()).rejects.toThrow(
+      "Failed to initiate device authorization: 500",
+    );
+  });
+
+  test("polls the exact code endpoint and parses OK responses", async () => {
+    const response = { status: "approved", token: "token", userEmail: "user@example.com" };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify(response), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(pollDeviceAuth("code value")).resolves.toEqual(response);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/device-auth/codes/code value");
+  });
+
+  test.each([
+    [202, { status: "pending" }],
+    [403, { status: "denied" }],
+    [410, { status: "expired" }],
+  ])("maps status %s exactly", async (status, expected) => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status })));
+
+    await expect(pollDeviceAuth("code")).resolves.toEqual(expected);
+  });
+
+  test("throws the exact generic poll failure", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 500 })));
+
+    await expect(pollDeviceAuth("code")).rejects.toThrow(
+      "Failed to poll device authorization: 500",
+    );
+  });
+
+  test("resolves after the requested interval", async () => {
+    vi.useFakeTimers();
+    const promise = abortableSleep(3000);
+    await vi.advanceTimersByTimeAsync(2999);
+    let settled = false;
+    void promise.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test("rejects immediately when already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(abortableSleep(3000, controller.signal)).rejects.toThrow("Login cancelled");
+  });
+
+  test("rejects on mid-wait abort and clears the pending timeout", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const promise = abortableSleep(3000, controller.signal);
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("Login cancelled");
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(3000);
+  });
 });
 
 describe("getAgentDir", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,136 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  getAgentDir,
+  getCredentialOrganizationId,
+  getEffectiveOrganizationId,
+  getEnvOrganizationId,
+  readStoredKiloCredentials,
+} from "../auth.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("getAgentDir", () => {
+  test("uses PI_CODING_AGENT_DIR when set", () => {
+    vi.stubEnv("PI_CODING_AGENT_DIR", "/custom/agent");
+
+    expect(getAgentDir()).toBe("/custom/agent");
+  });
+
+  test("falls back to the homedir agent directory", () => {
+    vi.stubEnv("PI_CODING_AGENT_DIR", "");
+
+    expect(getAgentDir()).toBe(join(homedir(), ".pi", "agent"));
+  });
+});
+
+describe("readStoredKiloCredentials", () => {
+  function withAuthFile(contents: string): string {
+    const directory = mkdtempSync(join("/tmp", "kilo-auth-test-"));
+    temporaryDirectories.push(directory);
+    writeFileSync(join(directory, "auth.json"), contents);
+    vi.stubEnv("PI_CODING_AGENT_DIR", directory);
+    return directory;
+  }
+
+  test("returns valid OAuth credentials", () => {
+    withAuthFile(JSON.stringify({ kilo: { type: "oauth", access: "token" } }));
+
+    expect(readStoredKiloCredentials()).toEqual({ type: "oauth", access: "token" });
+  });
+
+  test.each([
+    ["missing file", undefined],
+    ["malformed JSON", "{"],
+    ["non-OAuth", JSON.stringify({ kilo: { type: "api_key", access: "token" } })],
+    ["missing access", JSON.stringify({ kilo: { type: "oauth" } })],
+    ["empty access", JSON.stringify({ kilo: { type: "oauth", access: "" } })],
+    ["absent kilo", JSON.stringify({ other: {} })],
+  ])("returns undefined for %s", (_name, contents) => {
+    if (contents === undefined) {
+      const directory = mkdtempSync(join("/tmp", "kilo-auth-test-"));
+      temporaryDirectories.push(directory);
+      vi.stubEnv("PI_CODING_AGENT_DIR", directory);
+    } else {
+      withAuthFile(contents);
+    }
+
+    expect(readStoredKiloCredentials()).toBeUndefined();
+  });
+});
+
+describe("organization helpers", () => {
+  test.each([
+    ["KILO_ORG_ID", "primary", "fallback", "primary"],
+    ["KILOCODE_ORGANIZATION_ID", "", "fallback", "fallback"],
+  ])("getEnvOrganizationId uses %s", (_name, kilo, kilocode, expected) => {
+    vi.stubEnv("KILO_ORG_ID", kilo);
+    vi.stubEnv("KILOCODE_ORGANIZATION_ID", kilocode);
+
+    expect(getEnvOrganizationId()).toBe(expected);
+  });
+
+  test("getEnvOrganizationId returns undefined when both are absent", () => {
+    const kilo = process.env.KILO_ORG_ID;
+    const kilocode = process.env.KILOCODE_ORGANIZATION_ID;
+    delete process.env.KILO_ORG_ID;
+    delete process.env.KILOCODE_ORGANIZATION_ID;
+
+    try {
+      expect(getEnvOrganizationId()).toBeUndefined();
+    } finally {
+      if (kilo === undefined) delete process.env.KILO_ORG_ID;
+      else process.env.KILO_ORG_ID = kilo;
+      if (kilocode === undefined) delete process.env.KILOCODE_ORGANIZATION_ID;
+      else process.env.KILOCODE_ORGANIZATION_ID = kilocode;
+    }
+  });
+
+  test("returns a nonempty account ID untrimmed", () => {
+    expect(getCredentialOrganizationId({ accountId: "  organization-id  " } as never)).toBe(
+      "  organization-id  ",
+    );
+  });
+
+  test.each([undefined, "   "])("returns undefined for missing or whitespace account ID: %j", (accountId) => {
+    expect(getCredentialOrganizationId({ accountId } as never)).toBeUndefined();
+  });
+
+  test("prefers credential organization over environment", () => {
+    vi.stubEnv("KILO_ORG_ID", "env-id");
+
+    expect(getEffectiveOrganizationId({ accountId: "credential-id" } as never)).toBe("credential-id");
+  });
+
+  test("falls back to environment organization", () => {
+    vi.stubEnv("KILO_ORG_ID", "env-id");
+
+    expect(getEffectiveOrganizationId()).toBe("env-id");
+  });
+
+  test("returns undefined when credential and environment organizations are absent", () => {
+    const kilo = process.env.KILO_ORG_ID;
+    const kilocode = process.env.KILOCODE_ORGANIZATION_ID;
+    delete process.env.KILO_ORG_ID;
+    delete process.env.KILOCODE_ORGANIZATION_ID;
+
+    try {
+      expect(getEffectiveOrganizationId()).toBeUndefined();
+    } finally {
+      if (kilo === undefined) delete process.env.KILO_ORG_ID;
+      else process.env.KILO_ORG_ID = kilo;
+      if (kilocode === undefined) delete process.env.KILOCODE_ORGANIZATION_ID;
+      else process.env.KILOCODE_ORGANIZATION_ID = kilocode;
+    }
+  });
+});

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -7,6 +7,7 @@ import {
   getAgentDir,
   getCredentialOrganizationId,
   initiateDeviceAuth,
+  loginKilo,
   pollDeviceAuth,
   selectKiloOrganization,
   getEffectiveOrganizationId,
@@ -23,6 +24,119 @@ afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+describe("loginKilo", () => {
+  function setupLoginFetch(responses: Response[]): ReturnType<typeof vi.fn<typeof fetch>> {
+    const fetchMock = vi.fn<typeof fetch>();
+    for (const response of responses) fetchMock.mockResolvedValueOnce(response);
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  test("reports initiation, auth instructions, waiting, and success progress", async () => {
+    vi.useFakeTimers();
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "abc", verificationUrl: "https://verify", expiresIn: 60 }), { status: 200 }),
+      new Response(JSON.stringify({ status: "approved", token: "token" }), { status: 200 }),
+      new Response(JSON.stringify({ organizations: [] }), { status: 200 }),
+    ]);
+    const onProgress = vi.fn();
+    const onAuth = vi.fn();
+    const promise = loginKilo({ onProgress, onAuth });
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(promise).resolves.toEqual(expect.objectContaining({ access: "token" }));
+    expect(onProgress.mock.calls).toEqual([
+      ["Initiating device authorization..."],
+      ["Waiting for browser authorization..."],
+      ["Login successful!"],
+      ["Fetching Kilo profile..."],
+    ]);
+    expect(onAuth).toHaveBeenCalledWith({
+      url: "https://verify",
+      instructions: "Enter code: abc",
+    });
+  });
+
+  test("returns pending then approved credentials with selected organization", async () => {
+    const now = 1_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 60 }), { status: 200 }),
+      new Response(null, { status: 202 }),
+      new Response(JSON.stringify({ status: "approved", token: "token" }), { status: 200 }),
+      new Response(JSON.stringify({ organizations: [{ id: "org", name: "Org" }] }), { status: 200 }),
+    ]);
+    const onProgress = vi.fn();
+    const onSelect = vi.fn().mockResolvedValue("org");
+
+    const promise = loginKilo({ onProgress, onSelect, onAuth: vi.fn() });
+    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(3000);
+    const credentials = await promise;
+
+    expect(credentials).toEqual({
+      refresh: "token",
+      access: "token",
+      expires: now + 6000 + 365 * 24 * 60 * 60 * 1000,
+      accountId: "org",
+    });
+    expect(onProgress).toHaveBeenCalledWith("Waiting for browser authorization... (57s remaining)");
+  });
+
+  test("omits accountId for personal selection", async () => {
+    vi.useFakeTimers();
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 60 }), { status: 200 }),
+      new Response(JSON.stringify({ status: "approved", token: "token" }), { status: 200 }),
+      new Response(JSON.stringify({ organizations: [{ id: "org", name: "Org" }] }), { status: 200 }),
+    ]);
+    const promise = loginKilo({ onSelect: vi.fn().mockResolvedValue("personal"), onAuth: vi.fn() });
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(promise).resolves.toEqual(expect.not.objectContaining({ accountId: expect.anything() }));
+  });
+
+  test.each([
+    ["approved missing token", { status: "approved" }, "Authorization approved but no token received"],
+    ["denied", { status: "denied" }, "Authorization denied by user."],
+    ["expired", { status: "expired" }, "Authorization code expired. Please try again."],
+  ])("throws exact error for %s", async (_name, result, message) => {
+    vi.useFakeTimers();
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 60 }), { status: 200 }),
+      new Response(JSON.stringify(result), { status: 200 }),
+      ...(result.status === "approved" ? [new Response(JSON.stringify({ organizations: [] }), { status: 200 })] : []),
+    ]);
+    const promise = loginKilo({ onAuth: vi.fn() });
+    const rejection = expect(promise).rejects.toThrow(message);
+    await vi.advanceTimersByTimeAsync(3000);
+    await rejection;
+  });
+
+  test("throws Login cancelled when aborted", async () => {
+    vi.useFakeTimers();
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 60 }), { status: 200 }),
+    ]);
+    const controller = new AbortController();
+    const promise = loginKilo({ signal: controller.signal, onAuth: vi.fn() });
+    const rejection = expect(promise).rejects.toThrow("Login cancelled");
+    controller.abort();
+    await rejection;
+  });
+
+  test("throws exact timeout after deadline exhaustion", async () => {
+    vi.useFakeTimers();
+    setupLoginFetch([
+      new Response(JSON.stringify({ code: "code", verificationUrl: "url", expiresIn: 3 }), { status: 200 }),
+      new Response(null, { status: 202 }),
+    ]);
+    const promise = loginKilo({ onAuth: vi.fn() });
+    const rejection = expect(promise).rejects.toThrow("Authentication timed out. Please try again.");
+    await vi.advanceTimersByTimeAsync(3000);
+    await rejection;
+  });
 });
 
 describe("device authorization", () => {

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   getAgentDir,
   getCredentialOrganizationId,
+  selectKiloOrganization,
   getEffectiveOrganizationId,
   getEnvOrganizationId,
   readStoredKiloCredentials,
@@ -66,6 +67,124 @@ describe("readStoredKiloCredentials", () => {
     }
 
     expect(readStoredKiloCredentials()).toBeUndefined();
+  });
+});
+
+describe("selectKiloOrganization", () => {
+  test("fetches the profile with the token and reports progress", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ organizations: [] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const onProgress = vi.fn();
+
+    await selectKiloOrganization("access-token", { onProgress });
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile", {
+      headers: {
+        Authorization: "Bearer access-token",
+        "Content-Type": "application/json",
+      },
+    });
+    expect(onProgress).toHaveBeenCalledWith("Fetching Kilo profile...");
+  });
+
+  test("returns a matching environment organization without prompting", async () => {
+    vi.stubEnv("KILO_ORG_ID", "org-2");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [{ id: "org-2", name: "Org 2" }] }), {
+          status: 200,
+        }),
+      ),
+    );
+    const onSelect = vi.fn();
+
+    await expect(selectKiloOrganization("token", { onSelect })).resolves.toBe("org-2");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test("returns the environment fallback without onSelect or organizations", async () => {
+    vi.stubEnv("KILO_ORG_ID", "env-org");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [] }), { status: 200 }),
+      ),
+    );
+
+    await expect(selectKiloOrganization("token", {})).resolves.toBe("env-org");
+  });
+
+  test("offers personal first and formats organization roles exactly", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org-1", name: "First", role: "admin" },
+              { id: "org-2", name: "Second" },
+            ],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    const onSelect = vi.fn().mockResolvedValue("org-2");
+
+    await selectKiloOrganization("token", { onSelect });
+
+    expect(onSelect).toHaveBeenCalledWith({
+      message: "Select Kilo account",
+      options: [
+        { id: "personal", label: "Personal Account" },
+        { id: "org-1", label: "First (admin)" },
+        { id: "org-2", label: "Second" },
+      ],
+    });
+  });
+
+  test.each([undefined, "personal"])("returns undefined for cancel or personal: %j", async (selected) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [{ id: "org-1", name: "Org 1" }] }), {
+          status: 200,
+        }),
+      ),
+    );
+    const onSelect = vi.fn().mockResolvedValue(selected);
+
+    await expect(selectKiloOrganization("token", { onSelect })).resolves.toBeUndefined();
+  });
+
+  test("returns the selected organization ID", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [{ id: "org-1", name: "Org 1" }] }), {
+          status: 200,
+        }),
+      ),
+    );
+
+    await expect(
+      selectKiloOrganization("token", { onSelect: vi.fn().mockResolvedValue("org-1") }),
+    ).resolves.toBe("org-1");
+  });
+
+  test("logs the exact warning and returns environment fallback on profile failure", async () => {
+    vi.stubEnv("KILO_ORG_ID", "env-org");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(new Error("network failure")));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(selectKiloOrganization("token", {})).resolves.toBe("env-org");
+    expect(warn).toHaveBeenCalledWith(
+      "[kilo] Failed to fetch profile for organization selection:",
+      "network failure",
+    );
   });
 });
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
@@ -15,12 +15,14 @@ import {
   getEnvOrganizationId,
   readStoredKiloCredentials,
 } from "../auth.ts";
+import { KILO_API_BASE } from "../api.ts";
 
 const temporaryDirectories: string[] = [];
 
 afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
   for (const directory of temporaryDirectories.splice(0)) {
     rmSync(directory, { recursive: true, force: true });
@@ -181,7 +183,7 @@ describe("device authorization", () => {
 
     await initiateDeviceAuth();
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/device-auth/codes", {
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/device-auth/codes`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     });
@@ -213,6 +215,13 @@ describe("device authorization", () => {
     );
   });
 
+  test("propagates an initiation fetch rejection unchanged", async () => {
+    const error = new Error("initiation network failure");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(error));
+
+    await expect(initiateDeviceAuth()).rejects.toBe(error);
+  });
+
   test("polls the exact code endpoint and parses OK responses", async () => {
     const response = { status: "approved", token: "token", userEmail: "user@example.com" };
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
@@ -221,7 +230,7 @@ describe("device authorization", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(pollDeviceAuth("code value")).resolves.toEqual(response);
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/device-auth/codes/code value");
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/device-auth/codes/code value`);
   });
 
   test.each([
@@ -240,6 +249,13 @@ describe("device authorization", () => {
     await expect(pollDeviceAuth("code")).rejects.toThrow(
       "Failed to poll device authorization: 500",
     );
+  });
+
+  test("propagates a poll fetch rejection unchanged", async () => {
+    const error = new Error("poll network failure");
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(error));
+
+    await expect(pollDeviceAuth("code")).rejects.toBe(error);
   });
 
   test("resolves after the requested interval", async () => {
@@ -291,7 +307,7 @@ describe("getAgentDir", () => {
 
 describe("readStoredKiloCredentials", () => {
   function withAuthFile(contents: string): string {
-    const directory = mkdtempSync(join("/tmp", "kilo-auth-test-"));
+    const directory = mkdtempSync(join(tmpdir(), "kilo-auth-test-"));
     temporaryDirectories.push(directory);
     writeFileSync(join(directory, "auth.json"), contents);
     vi.stubEnv("PI_CODING_AGENT_DIR", directory);
@@ -313,7 +329,7 @@ describe("readStoredKiloCredentials", () => {
     ["absent kilo", JSON.stringify({ other: {} })],
   ])("returns undefined for %s", (_name, contents) => {
     if (contents === undefined) {
-      const directory = mkdtempSync(join("/tmp", "kilo-auth-test-"));
+      const directory = mkdtempSync(join(tmpdir(), "kilo-auth-test-"));
       temporaryDirectories.push(directory);
       vi.stubEnv("PI_CODING_AGENT_DIR", directory);
     } else {
@@ -334,7 +350,7 @@ describe("selectKiloOrganization", () => {
 
     await selectKiloOrganization("access-token", { onProgress });
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.kilo.ai/api/profile", {
+    expect(fetchMock).toHaveBeenCalledWith(`${KILO_API_BASE}/api/profile`, {
       headers: {
         Authorization: "Bearer access-token",
         "Content-Type": "application/json",
@@ -365,6 +381,36 @@ describe("selectKiloOrganization", () => {
       "fetch",
       vi.fn<typeof fetch>().mockResolvedValue(
         new Response(JSON.stringify({ organizations: [] }), { status: 200 }),
+      ),
+    );
+
+    await expect(selectKiloOrganization("token", {})).resolves.toBe("env-org");
+  });
+
+  test("falls through to picker when environment organization is absent from profile", async () => {
+    vi.stubEnv("KILO_ORG_ID", "env-org");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [{ id: "other-org", name: "Other" }] }), {
+          status: 200,
+        }),
+      ),
+    );
+    const onSelect = vi.fn().mockResolvedValue("other-org");
+
+    await expect(selectKiloOrganization("token", { onSelect })).resolves.toBe("other-org");
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  test("returns environment fallback when organization is absent and no picker exists", async () => {
+    vi.stubEnv("KILO_ORG_ID", "env-org");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ organizations: [{ id: "other-org", name: "Other" }] }), {
+          status: 200,
+        }),
       ),
     );
 


### PR DESCRIPTION
## Summary

- Extract Kilo authentication, credentials, organization selection, and device login into `auth.ts`.
- Extract profile/balance HTTP calls and organization-header helpers into `api.ts`.
- Keep `kilo.ts` focused on provider, model, lifecycle, and footer integration.
- Add focused auth/API test coverage without changing runtime behavior.

Squash merge when approved.