### PR TITLE
chore: run Biome before commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,25 @@ Kilo credits remain available as the `kilo-credits` footer status.
 
 ## Development
 
-Install dependencies and run the tests:
+Install dependencies:
 
 ```bash
 npm ci
+```
+
+This installs [Prek](https://github.com/j178/prek)'s pre-commit hook. Before each commit it runs Biome, which applies safe formatting and lint fixes. If it changes files, review and stage those changes before committing again.
+
+Run the checks and tests directly with:
+
+```bash
+npm run check
 npm test
+```
+
+To run the pre-commit hook against every tracked file:
+
+```bash
+npx prek run --all-files
 ```
 
 ## License and attribution

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.5",
         "@earendil-works/pi-tui": "0.84.2",
+        "@j178/prek": "0.4.14",
         "vitest": "4.1.9"
       }
     },
@@ -189,6 +190,327 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@j178/prek": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek/-/prek-0.4.14.tgz",
+      "integrity": "sha512-MoLivxEG7LZK5dDTE0ItTZ4dMCOzr3Ln4JW4KUvsSqP3XI0Vokf1PrIb4fkrU58u2tpatFLQPU9dCSlIenGBAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prek": "bin/prek.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@j178/prek-android-arm64": "0.4.14",
+        "@j178/prek-darwin-arm64": "0.4.14",
+        "@j178/prek-darwin-x64": "0.4.14",
+        "@j178/prek-linux-arm-gnueabihf": "0.4.14",
+        "@j178/prek-linux-arm-musleabihf": "0.4.14",
+        "@j178/prek-linux-arm64-gnu": "0.4.14",
+        "@j178/prek-linux-arm64-musl": "0.4.14",
+        "@j178/prek-linux-armv7-musleabihf": "0.4.14",
+        "@j178/prek-linux-ia32-gnu": "0.4.14",
+        "@j178/prek-linux-ia32-musl": "0.4.14",
+        "@j178/prek-linux-riscv64-gnu": "0.4.14",
+        "@j178/prek-linux-s390x-gnu": "0.4.14",
+        "@j178/prek-linux-x64-gnu": "0.4.14",
+        "@j178/prek-linux-x64-musl": "0.4.14",
+        "@j178/prek-win32-arm64-msvc": "0.4.14",
+        "@j178/prek-win32-ia32-msvc": "0.4.14",
+        "@j178/prek-win32-x64-msvc": "0.4.14"
+      }
+    },
+    "node_modules/@j178/prek-android-arm64": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-android-arm64/-/prek-android-arm64-0.4.14.tgz",
+      "integrity": "sha512-GTpEk14YooeltrXbcOMsIPXoAj8YXrr0wQ5ck1CgHqptpiRmmjvJg+PvF0ZtFQg/tEaKh7cUd6QxuPPm8nF9gw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-arm64": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-arm64/-/prek-darwin-arm64-0.4.14.tgz",
+      "integrity": "sha512-uJbOVLLn0ags2uKJ1g1d9xRFTvbhlrsnRg5SAU5g9tSCx82eMZ5TQlt7GpELtbimJSDg2lfrJZnmXqW5FevWqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-darwin-x64": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-darwin-x64/-/prek-darwin-x64-0.4.14.tgz",
+      "integrity": "sha512-ZpSk1AqyEw302HTKP4j8cwGR/7fSs3BMH0QxdreYWCrkE1cigpbcbpLQa+mOovbRz/ye3s++O2XuO4m+3+LqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-gnueabihf": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-gnueabihf/-/prek-linux-arm-gnueabihf-0.4.14.tgz",
+      "integrity": "sha512-cjVYzK9kRdpUrVEKglzAFcISXyL5k4GnXhRz+h580aew5vpWljjNzFb/wzIUeHBPMCrG+gK8hfUApVtUauZD2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm-musleabihf": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm-musleabihf/-/prek-linux-arm-musleabihf-0.4.14.tgz",
+      "integrity": "sha512-HfSuYdl6kD1t+ePqFMgnac+MoMLu9qcHR16XLWFtBmao8VHqzsz/Yq6BLLZa3yyyvv3ah+aY+02ykvursIC/Vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-gnu": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-gnu/-/prek-linux-arm64-gnu-0.4.14.tgz",
+      "integrity": "sha512-AucV841FWZsLpccho7jIQWKlUSMHOXbir+zFgvWk7ZhKoXLhvrXUOvWbjF+UrIM5r6IoZCvg8fb3h2nMjBem8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-arm64-musl": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-arm64-musl/-/prek-linux-arm64-musl-0.4.14.tgz",
+      "integrity": "sha512-YSPkB4xTyguFFAkkXniXI2Fh6rClIk0hfjrbj2uUKYTAq6VHnrF6gyBf0IaAQd7N/u53RhXJQr5Zd1QMiSpkDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-armv7-musleabihf": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-armv7-musleabihf/-/prek-linux-armv7-musleabihf-0.4.14.tgz",
+      "integrity": "sha512-F+axK/S1G459ZiXhkYRtvvoYiP2T8s3H9OY9qvkOn64G19Fqo6kqvT0c8h3CwaV7+CZmBfrS6Ncy3kI5qT1OFw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-gnu": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-gnu/-/prek-linux-ia32-gnu-0.4.14.tgz",
+      "integrity": "sha512-ltu0OqYJikW8DSuOMLdRlwgZ2YbuUJlaYyGJH560gcaMC1kMmeVVgKb4j/GozQwN7H2TQsRWCVDHpr9ypOCgUw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-ia32-musl": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-ia32-musl/-/prek-linux-ia32-musl-0.4.14.tgz",
+      "integrity": "sha512-wL/3t5tXuLsUJBbEKt/W0j4oOli4C+gOmwNyt3t0kqc5oQLYlsna5zzezoK6G9iTQ2gfTQF+3hOsdVe4f9vwCg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-riscv64-gnu": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-riscv64-gnu/-/prek-linux-riscv64-gnu-0.4.14.tgz",
+      "integrity": "sha512-xJLMyjZDcIohJQ97xKmIaDC2CXQnYFZQk2/oPf5rMtQOtSp/WoNb4zHQsDfXbp942O62eHTB8HrQUZ19Bh7roA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-s390x-gnu": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-s390x-gnu/-/prek-linux-s390x-gnu-0.4.14.tgz",
+      "integrity": "sha512-q99kiIbYGk56ziasIfL3JxlBZ4xzDG238HP9Yhtrr0f0x46t6fCZ9p7vQyZFKXFeHi8e/mCTRztMY3jUx/6L8A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-gnu": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-gnu/-/prek-linux-x64-gnu-0.4.14.tgz",
+      "integrity": "sha512-OfBqc3Q9lOWtMZvXpY1myOLZrSGtUeBOiJR0YoZb2YCP/rZ5POk/0JBaH8zabJgwBtYWHtjlPZ/Fty5ml0YExw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-linux-x64-musl": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-linux-x64-musl/-/prek-linux-x64-musl-0.4.14.tgz",
+      "integrity": "sha512-bgIi/mRRDrZmrQ0wFWEC3mddJuVxiFdBIKWd/F+Qq0VkLwdwhOE62xsKEyQ4yr3Xu6UJkOTjLwGwMuVtnYE6Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-arm64-msvc": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-arm64-msvc/-/prek-win32-arm64-msvc-0.4.14.tgz",
+      "integrity": "sha512-NR50TLCoezu3wqkY6qwdOkhVnI3EUCbCYSbxmWALTlOxe/r/GFHRuIR92HLf0egNDdreKgBArF39MYynJGehLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-ia32-msvc": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-ia32-msvc/-/prek-win32-ia32-msvc-0.4.14.tgz",
+      "integrity": "sha512-HrH4TXMxX8CwJe6GhA7/xeJnqs/I5kAG01Khyiy8346RwhWhxQbmfmk2vy8CtnpONPTgzsWqd6o2QSTQ8+pLPg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@j178/prek-win32-x64-msvc": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@j178/prek-win32-x64-msvc/-/prek-win32-x64-msvc-0.4.14.tgz",
+      "integrity": "sha512-Dft4G8/nmL90aEc24vuTOYGHE5Kop6alRWMWvxlSIVo4veedTMIG+MBFzwamfKjKvaAAFG1sEXKRxlkzxAw2YQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "license": "BSL-1.0",
   "scripts": {
     "test": "vitest run",
-    "check": "biome check --write --error-on-warnings ."
+    "check": "biome check --write --error-on-warnings .",
+    "prepare": "prek install"
   },
   "pi": {
     "extensions": ["./kilo.ts"]
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.5",
     "@earendil-works/pi-tui": "0.84.2",
+    "@j178/prek": "0.4.14",
     "vitest": "4.1.9"
   }
 }

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,9 @@
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "biome"
+name = "Biome"
+language = "system"
+entry = "npm run check"
+pass_filenames = false

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -24,3 +24,12 @@ test("provides the upstream Pi Biome check", () => {
 		formatter: { enabled: true, indentStyle: "tab", indentWidth: 3, lineWidth: 120 },
 	});
 });
+
+test("installs a Prek hook that runs the Biome check", () => {
+	expect(packageJson.scripts.prepare).toBe("prek install");
+	expect(packageJson.devDependencies["@j178/prek"]).toBe("0.4.14");
+
+	const prekConfig = readFileSync(resolve(repositoryRoot, "prek.toml"), "utf8");
+	expect(prekConfig).toContain('entry = "npm run check"');
+	expect(prekConfig).toContain("pass_filenames = false");
+});


### PR DESCRIPTION
Install a Prek pre-commit hook that runs the existing Biome check. This gives contributors the same formatting and lint feedback locally before CI.

Document the hook, direct check command, and how to run it against all files.