### PR TITLE
refactor: extract Kilo model catalog mapping

### DIFF
--- a/kilo.ts
+++ b/kilo.ts
@@ -10,6 +10,10 @@
  */
 
 import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import { isFreeModel, mapOpenRouterModel, type OpenRouterModel, parsePrice } from "./models.ts";
+
+export { parsePrice };
+
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { fetchKiloBalance, KILO_API_BASE, KILO_ORG_HEADER, withOrganizationHeader } from "./api.ts";
@@ -26,7 +30,6 @@ import {
 // =============================================================================
 
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
-const KILO_OPENROUTER_BASE = `${KILO_API_BASE}/api/openrouter`;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const KILO_TOS_URL = "https://kilo.ai/terms";
 
@@ -46,213 +49,6 @@ function formatCredits(balance: number): string {
 // =============================================================================
 // Dynamic Model Loading
 // =============================================================================
-
-interface OpenRouterModel {
-	id: string;
-	name: string;
-	context_length: number;
-	max_completion_tokens?: number | null;
-	pricing?: {
-		prompt?: string | null;
-		completion?: string | null;
-		input_cache_write?: string | null;
-		input_cache_read?: string | null;
-	};
-	architecture?: {
-		input_modalities?: string[] | null;
-		output_modalities?: string[] | null;
-	};
-	top_provider?: { max_completion_tokens?: number | null };
-	supported_parameters?: string[];
-	opencode?: {
-		family?: string;
-		prompt?: string;
-		variants?: Record<
-			string,
-			{
-				reasoning?: {
-					enabled?: boolean;
-					effort?: string;
-				};
-				verbosity?: string;
-			}
-		>;
-		ai_sdk_provider?: string;
-	};
-}
-
-export function parsePrice(price: string | null | undefined): number {
-	if (!price) return 0;
-	const parsed = parseFloat(price);
-	if (Number.isNaN(parsed)) return 0;
-	// OpenRouter prices are per-token; Pi expects per-million-token
-	return parsed * 1_000_000;
-}
-
-function isFreeModel(m: OpenRouterModel): boolean {
-	const prompt = parseFloat(m.pricing?.prompt ?? "1");
-	const completion = parseFloat(m.pricing?.completion ?? "1");
-	if (prompt !== 0 || completion !== 0) return false;
-	// Zero pricing alone isn't reliable (some models report "0" but require auth).
-	// Use the :free suffix (OpenRouter convention), Kilo-native models (no vendor
-	// prefix), or known Kilo/OpenRouter free routers.
-	if (m.id === "kilo-auto/free") return true;
-	if (m.id.includes(":free")) return true;
-	if (!m.id.includes("/")) return true;
-	if (m.id.startsWith("kilo/") || m.id.startsWith("openrouter/")) return true;
-	return false;
-}
-
-type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
-
-type KiloModelCompat = {
-	thinkingFormat?: "openrouter";
-	cacheControlFormat?: "anthropic";
-	requiresReasoningContentOnAssistantMessages?: boolean;
-	supportsStore?: boolean;
-	sendSessionIdHeader?: boolean;
-	supportsLongCacheRetention?: boolean;
-};
-
-function shouldUseResponsesApi(m: OpenRouterModel): boolean {
-	const aiSdkProvider = m.opencode?.ai_sdk_provider;
-	if (aiSdkProvider === "openai") return true;
-
-	// Some model metadata may arrive before ai_sdk_provider is populated. KiloCode
-	// routes current OpenAI reasoning/frontier models through the Responses API;
-	// using chat completions for these yields: "please use any of: responses".
-	const id = m.id.toLowerCase();
-	const shortId = id.includes("/") ? (id.split("/").pop() ?? id) : id;
-	return (
-		shortId === "gpt-5" ||
-		shortId.startsWith("gpt-5.") ||
-		shortId.startsWith("gpt-5-") ||
-		shortId.startsWith("o1") ||
-		shortId.startsWith("o3") ||
-		shortId.startsWith("o4")
-	);
-}
-
-function getKiloModelCompat(m: OpenRouterModel, api: Api | undefined): ProviderModelConfig["compat"] {
-	if (api === "openai-responses") {
-		return {
-			// Kilo/OpenRouter-compatible responses endpoints do not need OpenAI's
-			// session_id header, and long prompt-cache retention is provider-specific.
-			sendSessionIdHeader: false,
-			supportsLongCacheRetention: false,
-		} as ProviderModelConfig["compat"];
-	}
-
-	const compat: KiloModelCompat = {
-		// Kilo's gateway is OpenRouter-compatible, but it uses api.kilo.ai so
-		// pi-ai's URL/provider auto-detection cannot infer OpenRouter model quirks.
-		thinkingFormat: "openrouter",
-		supportsStore: false,
-	};
-
-	if (m.id.startsWith("anthropic/")) {
-		compat.cacheControlFormat = "anthropic";
-	}
-
-	if (m.id === "deepseek/deepseek-v4-flash" || m.id === "deepseek/deepseek-v4-pro") {
-		compat.requiresReasoningContentOnAssistantMessages = true;
-	}
-
-	return compat as ProviderModelConfig["compat"];
-}
-
-function mapVariantEffort(
-	variants: NonNullable<OpenRouterModel["opencode"]>["variants"],
-	key: string,
-): string | undefined {
-	const variant = variants?.[key];
-	if (!variant) return undefined;
-	const reasoning = variant.reasoning;
-	if (!reasoning) return key;
-	if (reasoning.enabled === false || reasoning.effort === "none") return "none";
-	return reasoning.effort ?? key;
-}
-
-function thinkingLevelMapFromVariants(
-	variants: NonNullable<OpenRouterModel["opencode"]>["variants"],
-): ProviderModelConfig["thinkingLevelMap"] | undefined {
-	if (!variants || Object.keys(variants).length === 0) return undefined;
-
-	const map: Partial<Record<PiThinkingLevel, string | null>> = {};
-	const off = mapVariantEffort(variants, "none") ?? mapVariantEffort(variants, "instant");
-	if (off !== undefined) map.off = off;
-
-	for (const level of ["minimal", "low", "medium", "high", "xhigh"] as const) {
-		const effort = mapVariantEffort(variants, level);
-		map[level] = effort === undefined ? null : effort;
-	}
-
-	// Pi has no separate "max" thinking level. Expose a Kilo/OpenCode max
-	// variant as Pi's xhigh when xhigh is absent.
-	if (map.xhigh === null) {
-		const max = mapVariantEffort(variants, "max");
-		if (max !== undefined) map.xhigh = max;
-	}
-
-	return map as ProviderModelConfig["thinkingLevelMap"];
-}
-
-function getKiloThinkingLevelMap(m: OpenRouterModel): ProviderModelConfig["thinkingLevelMap"] | undefined {
-	const fromVariants = thinkingLevelMapFromVariants(m.opencode?.variants);
-	if (fromVariants) return fromVariants;
-
-	if (m.id === "deepseek/deepseek-v4-pro") {
-		return {
-			minimal: null,
-			low: null,
-			medium: null,
-			high: "high",
-			xhigh: "max",
-		};
-	}
-
-	// Safety net for the current frontier OpenAI model while Kilo/OpenRouter
-	// model metadata is catching up.
-	if (m.id.includes("gpt-5.5")) {
-		return {
-			off: "none",
-			minimal: null,
-			low: "low",
-			medium: "medium",
-			high: "high",
-			xhigh: "xhigh",
-		};
-	}
-
-	return undefined;
-}
-
-function mapOpenRouterModel(m: OpenRouterModel): ProviderModelConfig {
-	const inputModalities = m.architecture?.input_modalities ?? ["text"];
-	const supportsImages = inputModalities.includes("image");
-	const supportsReasoning = m.supported_parameters?.includes("reasoning") ?? false;
-	const maxTokens =
-		m.top_provider?.max_completion_tokens ?? m.max_completion_tokens ?? Math.ceil(m.context_length * 0.2);
-	const api = shouldUseResponsesApi(m) ? ("openai-responses" as const) : undefined;
-
-	return {
-		id: m.id,
-		name: m.name,
-		...(api ? { api, baseUrl: KILO_OPENROUTER_BASE } : {}),
-		reasoning: supportsReasoning,
-		input: supportsImages ? ["text", "image"] : ["text"],
-		cost: {
-			input: parsePrice(m.pricing?.prompt),
-			output: parsePrice(m.pricing?.completion),
-			cacheRead: parsePrice(m.pricing?.input_cache_read),
-			cacheWrite: parsePrice(m.pricing?.input_cache_write),
-		},
-		contextWindow: m.context_length,
-		maxTokens: maxTokens,
-		thinkingLevelMap: getKiloThinkingLevelMap(m),
-		compat: getKiloModelCompat(m, api),
-	};
-}
 
 async function fetchKiloModels(options?: {
 	token?: string;

--- a/models.ts
+++ b/models.ts
@@ -1,0 +1,198 @@
+import type { Api } from "@earendil-works/pi-ai";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { KILO_API_BASE } from "./api.ts";
+
+const KILO_OPENROUTER_BASE = `${KILO_API_BASE}/api/openrouter`;
+
+export interface OpenRouterModel {
+	id: string;
+	name: string;
+	context_length: number;
+	max_completion_tokens?: number | null;
+	pricing?: {
+		prompt?: string | null;
+		completion?: string | null;
+		input_cache_write?: string | null;
+		input_cache_read?: string | null;
+	};
+	architecture?: {
+		input_modalities?: string[] | null;
+		output_modalities?: string[] | null;
+	};
+	top_provider?: { max_completion_tokens?: number | null };
+	supported_parameters?: string[];
+	opencode?: {
+		family?: string;
+		prompt?: string;
+		variants?: Record<
+			string,
+			{
+				reasoning?: {
+					enabled?: boolean;
+					effort?: string;
+				};
+				verbosity?: string;
+			}
+		>;
+		ai_sdk_provider?: string;
+	};
+}
+
+export function parsePrice(price: string | null | undefined): number {
+	if (!price) return 0;
+	const parsed = parseFloat(price);
+	if (Number.isNaN(parsed)) return 0;
+	// OpenRouter prices are per-token; Pi expects per-million-token
+	return parsed * 1_000_000;
+}
+
+export function isFreeModel(m: OpenRouterModel): boolean {
+	const prompt = parseFloat(m.pricing?.prompt ?? "1");
+	const completion = parseFloat(m.pricing?.completion ?? "1");
+	if (prompt !== 0 || completion !== 0) return false;
+	// Zero pricing alone isn't reliable (some models report "0" but require auth).
+	// Use the :free suffix (OpenRouter convention), Kilo-native models (no vendor
+	// prefix), or known Kilo/OpenRouter free routers.
+	if (m.id === "kilo-auto/free") return true;
+	if (m.id.includes(":free")) return true;
+	if (!m.id.includes("/")) return true;
+	if (m.id.startsWith("kilo/") || m.id.startsWith("openrouter/")) return true;
+	return false;
+}
+
+type PiThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+type KiloModelCompat = {
+	thinkingFormat?: "openrouter";
+	cacheControlFormat?: "anthropic";
+	requiresReasoningContentOnAssistantMessages?: boolean;
+	supportsStore?: boolean;
+	sendSessionIdHeader?: boolean;
+	supportsLongCacheRetention?: boolean;
+};
+
+function shouldUseResponsesApi(m: OpenRouterModel): boolean {
+	const aiSdkProvider = m.opencode?.ai_sdk_provider;
+	if (aiSdkProvider === "openai") return true;
+
+	// Some model metadata may arrive before ai_sdk_provider is populated. KiloCode
+	// routes current OpenAI reasoning/frontier models through the Responses API;
+	// using chat completions for these yields: "please use any of: responses".
+	const id = m.id.toLowerCase();
+	const shortId = id.includes("/") ? (id.split("/").pop() ?? id) : id;
+	return (
+		shortId === "gpt-5" ||
+		shortId.startsWith("gpt-5.") ||
+		shortId.startsWith("gpt-5-") ||
+		shortId.startsWith("o1") ||
+		shortId.startsWith("o3") ||
+		shortId.startsWith("o4")
+	);
+}
+
+function getKiloModelCompat(m: OpenRouterModel, api: Api | undefined): ProviderModelConfig["compat"] {
+	if (api === "openai-responses") {
+		return {
+			// Kilo/OpenRouter-compatible responses endpoints do not need OpenAI's
+			// session_id header, and long prompt-cache retention is provider-specific.
+			sendSessionIdHeader: false,
+			supportsLongCacheRetention: false,
+		} as ProviderModelConfig["compat"];
+	}
+
+	const compat: KiloModelCompat = {
+		// Kilo's gateway is OpenRouter-compatible, but it uses api.kilo.ai so
+		// pi-ai's URL/provider auto-detection cannot infer OpenRouter model quirks.
+		thinkingFormat: "openrouter",
+		supportsStore: false,
+	};
+
+	if (m.id.startsWith("anthropic/")) {
+		compat.cacheControlFormat = "anthropic";
+	}
+
+	if (m.id === "deepseek/deepseek-v4-flash" || m.id === "deepseek/deepseek-v4-pro") {
+		compat.requiresReasoningContentOnAssistantMessages = true;
+	}
+
+	return compat as ProviderModelConfig["compat"];
+}
+
+function mapVariantEffort(
+	variants: NonNullable<OpenRouterModel["opencode"]>["variants"],
+	key: string,
+): string | undefined {
+	const variant = variants?.[key];
+	if (!variant) return undefined;
+	const reasoning = variant.reasoning;
+	if (!reasoning) return key;
+	if (reasoning.enabled === false || reasoning.effort === "none") return "none";
+	return reasoning.effort ?? key;
+}
+
+function thinkingLevelMapFromVariants(
+	variants: NonNullable<OpenRouterModel["opencode"]>["variants"],
+): ProviderModelConfig["thinkingLevelMap"] | undefined {
+	if (!variants || Object.keys(variants).length === 0) return undefined;
+
+	const map: Partial<Record<PiThinkingLevel, string | null>> = {};
+	const off = mapVariantEffort(variants, "none") ?? mapVariantEffort(variants, "instant");
+	if (off !== undefined) map.off = off;
+
+	for (const level of ["minimal", "low", "medium", "high", "xhigh", "max"] as const) {
+		const effort = mapVariantEffort(variants, level);
+		map[level] = effort === undefined ? null : effort;
+	}
+
+	return map as ProviderModelConfig["thinkingLevelMap"];
+}
+
+function getKiloThinkingLevelMap(m: OpenRouterModel): ProviderModelConfig["thinkingLevelMap"] | undefined {
+	const fromVariants = thinkingLevelMapFromVariants(m.opencode?.variants);
+	if (/^deepseek\/deepseek-v4-(flash|pro)(?:-|$)/.test(m.id)) {
+		return { ...fromVariants, max: "max" };
+	}
+	if (fromVariants) return fromVariants;
+
+	// Safety net for the current frontier OpenAI model while Kilo/OpenRouter
+	// model metadata is catching up.
+	if (m.id.includes("gpt-5.5")) {
+		return {
+			off: "none",
+			minimal: null,
+			low: "low",
+			medium: "medium",
+			high: "high",
+			xhigh: "xhigh",
+		};
+	}
+
+	return undefined;
+}
+
+export function mapOpenRouterModel(m: OpenRouterModel): ProviderModelConfig {
+	const inputModalities = m.architecture?.input_modalities ?? ["text"];
+	const supportsImages = inputModalities.includes("image");
+	const supportsReasoning = m.supported_parameters?.includes("reasoning") ?? false;
+	const maxTokens =
+		m.top_provider?.max_completion_tokens ?? m.max_completion_tokens ?? Math.ceil(m.context_length * 0.2);
+	const api = shouldUseResponsesApi(m) ? ("openai-responses" as const) : undefined;
+
+	return {
+		id: m.id,
+		name: m.name,
+		...(api ? { api, baseUrl: KILO_OPENROUTER_BASE } : {}),
+		reasoning: supportsReasoning,
+		input: supportsImages ? ["text", "image"] : ["text"],
+		cost: {
+			input: parsePrice(m.pricing?.prompt),
+			output: parsePrice(m.pricing?.completion),
+			cacheRead: parsePrice(m.pricing?.input_cache_read),
+			cacheWrite: parsePrice(m.pricing?.input_cache_write),
+		},
+		contextWindow: m.context_length,
+		maxTokens: maxTokens,
+		thinkingLevelMap: getKiloThinkingLevelMap(m),
+		compat: getKiloModelCompat(m, api),
+	};
+}

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { mapOpenRouterModel, type OpenRouterModel } from "../models.ts";
+
+const modelWithGatewayVariants: OpenRouterModel = {
+	id: "acme/reasoning-model",
+	name: "Acme Reasoning Model",
+	context_length: 128_000,
+	supported_parameters: ["reasoning"],
+	opencode: {
+		variants: {
+			none: { reasoning: { enabled: false } },
+			high: { reasoning: { effort: "high" } },
+			xhigh: { reasoning: { effort: "xhigh" } },
+		},
+	},
+};
+
+describe("mapOpenRouterModel", () => {
+	test("maps gateway thinking variants", () => {
+		expect(mapOpenRouterModel(modelWithGatewayVariants).thinkingLevelMap).toEqual({
+			off: "none",
+			minimal: null,
+			low: null,
+			medium: null,
+			high: "high",
+			xhigh: "xhigh",
+			max: null,
+		});
+	});
+
+	test.each([
+		"deepseek/deepseek-v4-flash",
+		"deepseek/deepseek-v4-flash-0731",
+		"deepseek/deepseek-v4-pro",
+		"deepseek/deepseek-v4-pro-0813",
+	])("exposes max thinking for %s when the gateway omits it", (id) => {
+		expect(mapOpenRouterModel({ ...modelWithGatewayVariants, id }).thinkingLevelMap).toEqual({
+			off: "none",
+			minimal: null,
+			low: null,
+			medium: null,
+			high: "high",
+			xhigh: "xhigh",
+			max: "max",
+		});
+	});
+});


### PR DESCRIPTION
Move pure catalog mapping into a dedicated module with direct coverage for gateway thinking variants. Update the mapping to support Pi's max thinking level; this also exposes the documented DeepSeek V4 max variant when the gateway metadata omits it.

Fixes #3