### PR TITLE
fix: support API keys in authenticated runtime paths

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -40,6 +40,22 @@ export function getEffectiveOrganizationId(credentials?: OAuthCredentials): stri
 	return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
 }
 
+export interface KiloAccess {
+	token: string;
+	organizationId?: string;
+}
+
+export function getKiloAccess(): KiloAccess | undefined {
+	const credentials = readStoredKiloCredentials();
+	const token = credentials?.access ?? process.env.KILO_API_KEY;
+	if (!token) return undefined;
+
+	return {
+		token,
+		organizationId: getEffectiveOrganizationId(credentials),
+	};
+}
+
 interface DeviceAuthResponse {
 	code: string;
 	verificationUrl: string;

--- a/kilo.ts
+++ b/kilo.ts
@@ -20,6 +20,7 @@ import { fetchKiloBalance, KILO_API_BASE, KILO_ORG_HEADER, withOrganizationHeade
 import {
 	getEffectiveOrganizationId,
 	getEnvOrganizationId,
+	getKiloAccess,
 	loginKilo,
 	readStoredKiloCredentials,
 	refreshKiloToken,
@@ -120,19 +121,17 @@ function makeProviderConfig(organizationId?: string) {
 // =============================================================================
 
 export default async function (pi: ExtensionAPI) {
-	const storedCredentials = readStoredKiloCredentials();
-	const startupCatalogToken = storedCredentials?.access ?? process.env.KILO_API_KEY;
-	const startupOrganizationId = getEffectiveOrganizationId(storedCredentials);
+	const startupAccess = getKiloAccess();
 
 	// Fetch models at load time so the provider is immediately usable for
 	// --list-models, --model selection, and print mode before session_start fires.
 	let freeModels: ProviderModelConfig[] = [];
 	let cachedAllModels: ProviderModelConfig[] = [];
 	try {
-		if (startupCatalogToken) {
+		if (startupAccess) {
 			cachedAllModels = await fetchKiloModels({
-				token: startupCatalogToken,
-				organizationId: startupOrganizationId,
+				token: startupAccess.token,
+				organizationId: startupAccess.organizationId,
 			});
 			freeModels = cachedAllModels.length > 0 ? cachedAllModels : [];
 		} else {
@@ -209,18 +208,18 @@ export default async function (pi: ExtensionAPI) {
 	// After session starts, pre-fetch all models if already logged in so
 	// modifyModels has data to work with. Also fetch and display credits.
 	pi.on("session_start", async (_event, ctx) => {
-		const cred = readStoredKiloCredentials();
+		const access = getKiloAccess();
 
 		// Clear credits if not logged in
-		if (cred?.type !== "oauth") {
+		if (!access) {
 			ctx.ui.setStatus("kilo-credits", undefined);
 			return;
 		}
 
 		try {
 			cachedAllModels = await fetchKiloModels({
-				token: cred.access,
-				organizationId: getEffectiveOrganizationId(cred),
+				token: access.token,
+				organizationId: access.organizationId,
 			});
 		} catch (error) {
 			console.warn(
@@ -232,7 +231,7 @@ export default async function (pi: ExtensionAPI) {
 		if (cachedAllModels.length > 0) {
 			// Re-register to trigger modifyModels with the cached data.
 			ctx.modelRegistry.registerProvider("kilo", {
-				...makeProviderConfig(getEffectiveOrganizationId(cred)),
+				...makeProviderConfig(access.organizationId),
 				models: freeModels,
 				oauth: makeOAuthConfig(),
 			});
@@ -241,7 +240,7 @@ export default async function (pi: ExtensionAPI) {
 		// Fetch and display credits balance when an interactive UI is available.
 		if (ctx.hasUI) {
 			try {
-				const balance = await fetchKiloBalance(cred.access, getEffectiveOrganizationId(cred));
+				const balance = await fetchKiloBalance(access.token, access.organizationId);
 				if (balance !== null) {
 					const theme = ctx.ui.theme;
 					ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));

--- a/kilo.ts
+++ b/kilo.ts
@@ -22,7 +22,6 @@ import {
 	getEnvOrganizationId,
 	getKiloAccess,
 	loginKilo,
-	readStoredKiloCredentials,
 	refreshKiloToken,
 } from "./auth.ts";
 
@@ -299,8 +298,7 @@ export default async function (pi: ExtensionAPI) {
 		if (tosShown) return;
 		if (ctx.model?.provider !== "kilo") return;
 
-		const cred = readStoredKiloCredentials();
-		if (cred?.type === "oauth") {
+		if (getKiloAccess()) {
 			tosShown = true;
 			return;
 		}

--- a/kilo.ts
+++ b/kilo.ts
@@ -255,13 +255,13 @@ export default async function (pi: ExtensionAPI) {
 	pi.on("model_select", async (event, ctx) => {
 		if (event.model?.provider !== "kilo") return;
 
-		const cred = readStoredKiloCredentials();
-		if (cred?.type !== "oauth") return;
+		const access = getKiloAccess();
+		if (!access) return;
 
 		if (!ctx.hasUI) return;
 
 		try {
-			const balance = await fetchKiloBalance(cred.access, getEffectiveOrganizationId(cred));
+			const balance = await fetchKiloBalance(access.token, access.organizationId);
 			if (balance !== null) {
 				const theme = ctx.ui.theme;
 				ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));
@@ -276,13 +276,13 @@ export default async function (pi: ExtensionAPI) {
 
 	// Refresh credits after each turn
 	pi.on("turn_end", async (_event, ctx) => {
-		const cred = readStoredKiloCredentials();
-		if (cred?.type !== "oauth") return;
+		const access = getKiloAccess();
+		if (!access) return;
 
 		if (!ctx.hasUI) return;
 
 		try {
-			const balance = await fetchKiloBalance(cred.access, getEffectiveOrganizationId(cred));
+			const balance = await fetchKiloBalance(access.token, access.organizationId);
 			if (balance !== null) {
 				const theme = ctx.ui.theme;
 				ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -9,6 +9,7 @@ import {
 	getCredentialOrganizationId,
 	getEffectiveOrganizationId,
 	getEnvOrganizationId,
+	getKiloAccess,
 	initiateDeviceAuth,
 	loginKilo,
 	pollDeviceAuth,
@@ -307,15 +308,15 @@ describe("getAgentDir", () => {
 	});
 });
 
-describe("readStoredKiloCredentials", () => {
-	function withAuthFile(contents: string): string {
-		const directory = mkdtempSync(join(tmpdir(), "kilo-auth-test-"));
-		temporaryDirectories.push(directory);
-		writeFileSync(join(directory, "auth.json"), contents);
-		vi.stubEnv("PI_CODING_AGENT_DIR", directory);
-		return directory;
-	}
+function withAuthFile(contents: string): string {
+	const directory = mkdtempSync(join(tmpdir(), "kilo-auth-test-"));
+	temporaryDirectories.push(directory);
+	writeFileSync(join(directory, "auth.json"), contents);
+	vi.stubEnv("PI_CODING_AGENT_DIR", directory);
+	return directory;
+}
 
+describe("readStoredKiloCredentials", () => {
 	test("returns valid OAuth credentials", () => {
 		withAuthFile(JSON.stringify({ kilo: { type: "oauth", access: "token" } }));
 
@@ -339,6 +340,41 @@ describe("readStoredKiloCredentials", () => {
 		}
 
 		expect(readStoredKiloCredentials()).toBeUndefined();
+	});
+});
+
+describe("getKiloAccess", () => {
+	test("prefers stored OAuth access and account organization over environment values", () => {
+		withAuthFile(JSON.stringify({ kilo: { type: "oauth", access: "oauth-token", accountId: "account-org" } }));
+		vi.stubEnv("KILO_API_KEY", "api-key");
+		vi.stubEnv("KILO_ORG_ID", "env-org");
+
+		expect(getKiloAccess()).toEqual({ token: "oauth-token", organizationId: "account-org" });
+	});
+
+	test("uses KILO_ORG_ID before KILOCODE_ORGANIZATION_ID for API-key access", () => {
+		withAuthFile(JSON.stringify({}));
+		vi.stubEnv("KILO_API_KEY", "api-key");
+		vi.stubEnv("KILO_ORG_ID", "kilo-org");
+		vi.stubEnv("KILOCODE_ORGANIZATION_ID", "legacy-org");
+
+		expect(getKiloAccess()).toEqual({ token: "api-key", organizationId: "kilo-org" });
+	});
+
+	test("uses KILOCODE_ORGANIZATION_ID for API-key-only access when needed", () => {
+		withAuthFile(JSON.stringify({}));
+		vi.stubEnv("KILO_API_KEY", "api-key");
+		vi.stubEnv("KILO_ORG_ID", "");
+		vi.stubEnv("KILOCODE_ORGANIZATION_ID", "legacy-org");
+
+		expect(getKiloAccess()).toEqual({ token: "api-key", organizationId: "legacy-org" });
+	});
+
+	test("returns undefined without OAuth credentials or an API key", () => {
+		withAuthFile(JSON.stringify({}));
+		vi.stubEnv("KILO_API_KEY", "");
+
+		expect(getKiloAccess()).toBeUndefined();
 	});
 });
 

--- a/test/kilo.test.ts
+++ b/test/kilo.test.ts
@@ -466,6 +466,52 @@ test("session_start clears credits and makes no authenticated request without au
 	expect(setStatus).toHaveBeenCalledWith("kilo-credits", undefined);
 });
 
+test("before_agent_start suppresses the ToS notice for API-key and OAuth access", async () => {
+	for (const auth of [{}, { kilo: { type: "oauth", access: "oauth-token" } }]) {
+		isolateAuth(auth);
+		if (Object.keys(auth).length === 0) vi.stubEnv("KILO_API_KEY", "api-key");
+		vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(catalogResponse()));
+		const on = vi.fn();
+
+		await kiloExtension({ registerProvider: vi.fn(), on } as never);
+		const handler = on.mock.calls.find(([event]) => event === "before_agent_start")?.[1] as never;
+		await expect(handler({}, { model: { provider: "kilo" } })).resolves.toBeUndefined();
+	}
+});
+
+test("before_agent_start returns the exact notice only for unauthenticated Kilo use", async () => {
+	isolateAuth();
+	vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(catalogResponse()));
+	const on = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const handler = on.mock.calls.find(([event]) => event === "before_agent_start")?.[1] as never;
+	const context = { model: { provider: "kilo" } };
+	const expected = {
+		message: {
+			customType: "kilo",
+			content: "By using Kilo, you agree to the Terms of Service: https://kilo.ai/terms",
+			display: true,
+		},
+	};
+
+	await expect(handler({}, context)).resolves.toEqual(expected);
+	await expect(handler({}, context)).resolves.toBeUndefined();
+});
+
+test("before_agent_start does not consume the notice for another provider", async () => {
+	isolateAuth();
+	vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(catalogResponse()));
+	const on = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const handler = on.mock.calls.find(([event]) => event === "before_agent_start")?.[1] as never;
+	await expect(handler({}, { model: { provider: "other" } })).resolves.toBeUndefined();
+	await expect(handler({}, { model: { provider: "kilo" } })).resolves.toMatchObject({
+		message: { customType: "kilo", display: true },
+	});
+});
+
 test("session_start refreshes the catalog without balance work when UI is unavailable", async () => {
 	isolateAuth();
 	vi.stubEnv("KILO_API_KEY", "api-key");

--- a/test/kilo.test.ts
+++ b/test/kilo.test.ts
@@ -16,6 +16,25 @@ afterEach(() => {
 	}
 });
 
+function isolateAuth(auth: object = {}): void {
+	const agentDirectory = mkdtempSync(join(tmpdir(), "kilo-pi-provider-test-"));
+	temporaryDirectories.push(agentDirectory);
+	writeFileSync(join(agentDirectory, "auth.json"), JSON.stringify(auth));
+	vi.stubEnv("PI_CODING_AGENT_DIR", agentDirectory);
+	vi.stubEnv("KILO_API_KEY", "");
+	vi.stubEnv("KILO_ORG_ID", "");
+	vi.stubEnv("KILOCODE_ORGANIZATION_ID", "");
+	vi.stubEnv("KILO_CUSTOM_FOOTER", "0");
+}
+
+async function runSessionStart(on: ReturnType<typeof vi.fn>, context: object): Promise<void> {
+	const handler = on.mock.calls.find(([event]) => event === "session_start")?.[1] as
+		| ((event: unknown, context: unknown) => Promise<void>)
+		| undefined;
+	if (!handler) throw new Error("session_start handler not registered");
+	await handler({}, context);
+}
+
 const catalogResponse = () =>
 	new Response(
 		JSON.stringify({
@@ -225,4 +244,153 @@ test("loads the organization catalog with KILO_API_KEY", async () => {
 			}),
 		}),
 	);
+});
+
+test("session_start refreshes the catalog and credits for API-key-only access", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(catalogResponse())
+		.mockResolvedValueOnce(catalogResponse())
+		.mockResolvedValueOnce(new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }));
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await runSessionStart(on, {
+		hasUI: true,
+		ui: { setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
+		modelRegistry: { registerProvider: vi.fn() },
+	});
+
+	expect(fetchMock.mock.calls[1]?.[0]).toBe("https://api.kilo.ai/api/gateway/models");
+	expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+		expect.objectContaining({
+			headers: expect.objectContaining({ Authorization: "Bearer api-key" }),
+		}),
+	);
+	expect(fetchMock.mock.calls[2]?.[0]).toBe("https://api.kilo.ai/api/profile/balance");
+	expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
+});
+
+test("session_start uses the API key organization for catalog and balance", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	vi.stubEnv("KILO_ORG_ID", "org-id");
+	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+		if (String(input).endsWith("/balance")) {
+			return new Response(JSON.stringify({ balance: 12.34 }), { status: 200 });
+		}
+		return catalogResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const context = {
+		hasUI: true,
+		ui: { setStatus: vi.fn(), theme: { fg: vi.fn((_tone, text) => text) } },
+		modelRegistry: { registerProvider: vi.fn() },
+	};
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await runSessionStart(on, context);
+
+	expect(fetchMock.mock.calls[1]).toEqual([
+		"https://api.kilo.ai/api/organizations/org-id/models",
+		expect.objectContaining({
+			headers: expect.objectContaining({
+				Authorization: "Bearer api-key",
+				"X-KiloCode-OrganizationId": "org-id",
+			}),
+		}),
+	]);
+	expect(fetchMock.mock.calls[2]?.[1]).toEqual(
+		expect.objectContaining({
+			headers: {
+				Authorization: "Bearer api-key",
+				"Content-Type": "application/json",
+				"X-KiloCode-OrganizationId": "org-id",
+			},
+		}),
+	);
+});
+
+test("session_start prefers OAuth credentials and account organization over API-key env values", async () => {
+	isolateAuth({ kilo: { type: "oauth", access: "oauth-token", accountId: "account-org" } });
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	vi.stubEnv("KILO_ORG_ID", "env-org");
+	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+		if (String(input).endsWith("/balance")) {
+			return new Response(JSON.stringify({ balance: 12.34 }), { status: 200 });
+		}
+		return catalogResponse();
+	});
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const context = {
+		hasUI: true,
+		ui: { setStatus: vi.fn(), theme: { fg: vi.fn((_tone, text) => text) } },
+		modelRegistry: { registerProvider: vi.fn() },
+	};
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await runSessionStart(on, context);
+
+	for (const call of fetchMock.mock.calls.slice(0, 2)) {
+		expect(call[0]).toBe("https://api.kilo.ai/api/organizations/account-org/models");
+		expect(call[1]).toEqual(
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer oauth-token",
+					"X-KiloCode-OrganizationId": "account-org",
+				}),
+			}),
+		);
+	}
+	expect(fetchMock.mock.calls[2]).toEqual([
+		"https://api.kilo.ai/api/profile/balance",
+		expect.objectContaining({
+			headers: {
+				Authorization: "Bearer oauth-token",
+				"Content-Type": "application/json",
+				"X-KiloCode-OrganizationId": "account-org",
+			},
+		}),
+	]);
+});
+
+test("session_start clears credits and makes no authenticated request without auth", async () => {
+	isolateAuth();
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await runSessionStart(on, { hasUI: true, ui: { setStatus }, modelRegistry: { registerProvider: vi.fn() } });
+
+	expect(fetchMock).toHaveBeenCalledOnce();
+	expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.kilo.ai/api/gateway/models");
+	expect(setStatus).toHaveBeenCalledWith("kilo-credits", undefined);
+});
+
+test("session_start refreshes the catalog without balance work when UI is unavailable", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await runSessionStart(on, {
+		hasUI: false,
+		ui: { setStatus },
+		modelRegistry: { registerProvider: vi.fn() },
+	});
+
+	expect(fetchMock).toHaveBeenCalledTimes(2);
+	expect(fetchMock.mock.calls[1]?.[0]).toBe("https://api.kilo.ai/api/gateway/models");
+	expect(setStatus).not.toHaveBeenCalled();
 });

--- a/test/kilo.test.ts
+++ b/test/kilo.test.ts
@@ -360,6 +360,97 @@ test("session_start prefers OAuth credentials and account organization over API-
 	]);
 });
 
+test("model_select refreshes credits for API-key-only Kilo access", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	vi.stubEnv("KILO_ORG_ID", "org-id");
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(catalogResponse())
+		.mockResolvedValueOnce(new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }));
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const handler = on.mock.calls.find(([event]) => event === "model_select")?.[1] as never;
+	await handler(
+		{ model: { provider: "kilo" } },
+		{
+			hasUI: true,
+			ui: { setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
+		},
+	);
+
+	expect(fetchMock.mock.calls[1]).toEqual([
+		"https://api.kilo.ai/api/profile/balance",
+		expect.objectContaining({
+			headers: {
+				Authorization: "Bearer api-key",
+				"Content-Type": "application/json",
+				"X-KiloCode-OrganizationId": "org-id",
+			},
+		}),
+	]);
+	expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
+});
+
+test("model_select for another provider does not fetch balance", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const handler = on.mock.calls.find(([event]) => event === "model_select")?.[1] as never;
+	await handler({ model: { provider: "other" } }, { hasUI: true, ui: { setStatus } });
+
+	expect(fetchMock).toHaveBeenCalledOnce();
+	expect(setStatus).not.toHaveBeenCalled();
+});
+
+test("turn_end refreshes credits for API-key-only access", async () => {
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	const fetchMock = vi
+		.fn<typeof fetch>()
+		.mockResolvedValueOnce(catalogResponse())
+		.mockResolvedValueOnce(new Response(JSON.stringify({ balance: 12.34 }), { status: 200 }));
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const handler = on.mock.calls.find(([event]) => event === "turn_end")?.[1] as never;
+	await handler({}, { hasUI: true, ui: { setStatus, theme: { fg: vi.fn((_tone, text) => text) } } });
+
+	expect(fetchMock.mock.calls[1]?.[0]).toBe("https://api.kilo.ai/api/profile/balance");
+	expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
+});
+
+test("credit event guards skip missing access and missing UI", async () => {
+	isolateAuth();
+	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
+	vi.stubGlobal("fetch", fetchMock);
+	const on = vi.fn();
+	const setStatus = vi.fn();
+
+	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	const modelHandler = on.mock.calls.find(([event]) => event === "model_select")?.[1] as never;
+	await modelHandler({ model: { provider: "kilo" } }, { hasUI: true, ui: { setStatus } });
+	expect(fetchMock).toHaveBeenCalledOnce();
+	expect(setStatus).not.toHaveBeenCalled();
+
+	isolateAuth();
+	vi.stubEnv("KILO_API_KEY", "api-key");
+	const turnHandler = on.mock.calls.find(([event]) => event === "turn_end")?.[1] as never;
+	await turnHandler({}, { hasUI: false, ui: { setStatus } });
+	expect(fetchMock).toHaveBeenCalledOnce();
+	expect(setStatus).not.toHaveBeenCalled();
+});
+
 test("session_start clears credits and makes no authenticated request without auth", async () => {
 	isolateAuth();
 	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());


### PR DESCRIPTION
API-key users were treated as unauthenticated in several runtime paths, even though startup catalog loading already supported `KILO_API_KEY`.

- Use `KILO_API_KEY` for catalog and credit refreshes and ToS suppression.
- Preserve OAuth token and organization precedence.
- Add coverage for API-key, organization, OAuth precedence, and unauthenticated paths.

> **Merge note:** Please squash before merging.