### PR TITLE
fix: skip Prek hook setup during package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ Install dependencies:
 npm ci
 ```
 
-This installs [Prek](https://github.com/j178/prek)'s pre-commit hook. Before each commit it runs Biome, which applies safe formatting and lint fixes. If it changes files, review and stage those changes before committing again.
+Install [Prek](https://github.com/j178/prek)'s pre-commit hook locally:
+
+```bash
+npx prek install
+```
+
+Before each commit it runs Biome, which applies safe formatting and lint fixes. If it changes files, review and stage those changes before committing again. The hook is not installed automatically so Pi package installation, which omits development dependencies, succeeds.
 
 Run the checks and tests directly with:
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "check": "biome check --write --error-on-warnings .",
-    "prepare": "prek install"
+    "check": "biome check --write --error-on-warnings ."
   },
   "pi": {
     "extensions": ["./src/index.ts"]

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -25,8 +25,8 @@ test("provides the upstream Pi Biome check", () => {
 	});
 });
 
-test("installs a Prek hook that runs the Biome check", () => {
-	expect(packageJson.scripts.prepare).toBe("prek install");
+test("provides a Prek hook without running it during package installation", () => {
+	expect(packageJson.scripts.prepare).toBeUndefined();
 	expect(packageJson.devDependencies["@j178/prek"]).toBe("0.4.14");
 
 	const prekConfig = readFileSync(resolve(repositoryRoot, "prek.toml"), "utf8");


### PR DESCRIPTION
Pi installs package runtime dependencies with npm `--omit=dev`, so the Prek binary is unavailable during lifecycle scripts. Document explicit local hook installation instead.