### PR TITLE
Feat: expose daily usage from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ KILO_CUSTOM_FOOTER=0 pi
 
 Kilo credits remain available as the `kilo-credits` footer status.
 
+To show today's Kilo spend, opt in to usage status reporting:
+
+```bash
+KILO_USAGE=1 pi
+```
+
+`KILO_USAGE` also accepts `true`, `yes`, or `day`. Daily usage refreshes at session start and after completed turns.
+
 ## Development
 
 Source modules are under `src/`; `src/index.ts` is the Pi extension entry point.

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,12 @@
 export const KILO_API_BASE = process.env.KILO_API_URL || "https://api.kilo.ai";
 const KILO_PROFILE_ENDPOINT = `${KILO_API_BASE}/api/profile`;
 export const KILO_ORG_HEADER = "X-KiloCode-OrganizationId";
+const USAGE_FETCH_TIMEOUT_MS = 10_000;
+
+export interface KiloAccess {
+	token: string;
+	organizationId?: string;
+}
 
 export function withOrganizationHeader(
 	headers: Record<string, string>,
@@ -40,6 +46,48 @@ export async function fetchKiloProfile(token: string): Promise<KiloProfile> {
 
 interface KiloBalance {
 	balance?: number;
+}
+
+export type KiloUsageFetchPeriod = "week" | "month" | "year" | "all";
+
+export interface KiloUsageEntry {
+	date: string;
+	totalCostMicrodollars: number;
+}
+
+function isIsoDate(value: unknown): value is string {
+	if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+	const date = new Date(`${value}T00:00:00.000Z`);
+	return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value;
+}
+
+export async function fetchKiloUsageEntries(
+	access: KiloAccess,
+	period: KiloUsageFetchPeriod,
+): Promise<KiloUsageEntry[] | null> {
+	try {
+		const viewType = access.organizationId ?? "personal";
+		const response = await fetch(
+			`${KILO_PROFILE_ENDPOINT}/usage?period=${period}&viewType=${encodeURIComponent(viewType)}`,
+			{
+				headers: withOrganizationHeader({ Authorization: `Bearer ${access.token}` }, access.organizationId),
+				signal: AbortSignal.timeout(USAGE_FETCH_TIMEOUT_MS),
+			},
+		);
+		if (!response.ok) return null;
+
+		const data = (await response.json()) as { usage?: unknown };
+		if (!Array.isArray(data.usage)) return null;
+
+		return data.usage.flatMap((entry) => {
+			if (!entry || typeof entry !== "object") return [];
+			const { date, total_cost: totalCost } = entry as { date?: unknown; total_cost?: unknown };
+			if (!isIsoDate(date) || typeof totalCost !== "number" || !Number.isFinite(totalCost)) return [];
+			return [{ date, totalCostMicrodollars: totalCost }];
+		});
+	} catch {
+		return null;
+	}
 }
 
 export async function fetchKiloBalance(token: string, organizationId?: string): Promise<number | null> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import { fetchKiloProfile, KILO_API_BASE, type KiloProfile } from "./api.ts";
+import { fetchKiloProfile, KILO_API_BASE, type KiloAccess, type KiloProfile } from "./api.ts";
+
+export type { KiloAccess } from "./api.ts";
 
 const KILO_DEVICE_AUTH_ENDPOINT = `${KILO_API_BASE}/api/device-auth/codes`;
 const POLL_INTERVAL_MS = 3000;
@@ -38,11 +40,6 @@ export function getCredentialOrganizationId(credentials?: OAuthCredentials): str
 
 export function getEffectiveOrganizationId(credentials?: OAuthCredentials): string | undefined {
 	return getCredentialOrganizationId(credentials) ?? getEnvOrganizationId();
-}
-
-export interface KiloAccess {
-	token: string;
-	organizationId?: string;
 }
 
 export function getKiloAccess(): KiloAccess | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,13 @@ export { parsePrice };
 
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { fetchKiloBalance, KILO_API_BASE, KILO_ORG_HEADER, withOrganizationHeader } from "./api.ts";
+import {
+	fetchKiloBalance,
+	fetchKiloUsageEntries,
+	KILO_API_BASE,
+	KILO_ORG_HEADER,
+	withOrganizationHeader,
+} from "./api.ts";
 import {
 	getEffectiveOrganizationId,
 	getEnvOrganizationId,
@@ -24,6 +30,7 @@ import {
 	loginKilo,
 	refreshKiloToken,
 } from "./auth.ts";
+import { createUsageRefresher, getRequestedUsagePeriods } from "./usage.ts";
 
 // =============================================================================
 // Constants
@@ -126,6 +133,7 @@ export default async function (pi: ExtensionAPI) {
 	// --list-models, --model selection, and print mode before session_start fires.
 	let freeModels: ProviderModelConfig[] = [];
 	let cachedAllModels: ProviderModelConfig[] = [];
+	const usageRefresher = createUsageRefresher({ fetchUsageEntries: fetchKiloUsageEntries });
 	try {
 		if (startupAccess) {
 			cachedAllModels = await fetchKiloModels({
@@ -208,11 +216,25 @@ export default async function (pi: ExtensionAPI) {
 	// modifyModels has data to work with. Also fetch and display credits.
 	pi.on("session_start", async (_event, ctx) => {
 		const access = getKiloAccess();
+		const usageEnabled = getRequestedUsagePeriods().length > 0;
 
-		// Clear credits if not logged in
+		// Clear credits and enabled usage if not logged in.
 		if (!access) {
 			ctx.ui.setStatus("kilo-credits", undefined);
+			if (usageEnabled) {
+				usageRefresher.clear({
+					setStatus: (key, value) => ctx.ui.setStatus(key, value),
+					accent: (text) => text,
+				});
+			}
 			return;
+		}
+
+		if (ctx.hasUI && usageEnabled) {
+			usageRefresher.refresh(access, {
+				setStatus: (key, value) => ctx.ui.setStatus(key, value),
+				accent: (text) => ctx.ui.theme.fg("accent", text),
+			});
 		}
 
 		try {
@@ -273,12 +295,26 @@ export default async function (pi: ExtensionAPI) {
 		}
 	});
 
-	// Refresh credits after each turn
+	// Refresh credits and opt-in usage after each turn.
 	pi.on("turn_end", async (_event, ctx) => {
 		const access = getKiloAccess();
-		if (!access) return;
+		const usageEnabled = getRequestedUsagePeriods().length > 0;
+		if (!access || !ctx.hasUI) {
+			if (usageEnabled) {
+				usageRefresher.clear({
+					setStatus: (key, value) => ctx.ui.setStatus(key, value),
+					accent: (text) => text,
+				});
+			}
+			return;
+		}
 
-		if (!ctx.hasUI) return;
+		if (usageEnabled) {
+			usageRefresher.refresh(access, {
+				setStatus: (key, value) => ctx.ui.setStatus(key, value),
+				accent: (text) => ctx.ui.theme.fg("accent", text),
+			});
+		}
 
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -405,8 +441,13 @@ export default async function (pi: ExtensionAPI) {
 						statsParts.push(contextPercentStr);
 
 						// Inject credits inline on the main stats line
-						const creditsStatus = footerData.getExtensionStatuses().get("kilo-credits");
+						const extensionStatuses = footerData.getExtensionStatuses();
+						const creditsStatus = extensionStatuses.get("kilo-credits");
 						if (creditsStatus) statsParts.push(creditsStatus);
+						for (const period of ["day", "week", "month", "year"]) {
+							const usageStatus = extensionStatuses.get(`kilo-usage-${period}`);
+							if (usageStatus) statsParts.push(usageStatus);
+						}
 
 						let statsLeft = statsParts.join(" ");
 						let statsLeftWidth = visibleWidth(statsLeft);

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,15 +218,9 @@ export default async function (pi: ExtensionAPI) {
 		const access = getKiloAccess();
 		const usageEnabled = getRequestedUsagePeriods().length > 0;
 
-		// Clear credits and enabled usage if not logged in.
+		// Clear credits if not logged in.
 		if (!access) {
 			ctx.ui.setStatus("kilo-credits", undefined);
-			if (usageEnabled) {
-				usageRefresher.clear({
-					setStatus: (key, value) => ctx.ui.setStatus(key, value),
-					accent: (text) => text,
-				});
-			}
 			return;
 		}
 
@@ -299,15 +293,7 @@ export default async function (pi: ExtensionAPI) {
 	pi.on("turn_end", async (_event, ctx) => {
 		const access = getKiloAccess();
 		const usageEnabled = getRequestedUsagePeriods().length > 0;
-		if (!access || !ctx.hasUI) {
-			if (usageEnabled) {
-				usageRefresher.clear({
-					setStatus: (key, value) => ctx.ui.setStatus(key, value),
-					accent: (text) => text,
-				});
-			}
-			return;
-		}
+		if (!access || !ctx.hasUI) return;
 
 		if (usageEnabled) {
 			usageRefresher.refresh(access, {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -53,12 +53,6 @@ function getUsageStatusKey(period: KiloUsageDisplayPeriod): string {
 	return `${USAGE_STATUS_PREFIX}${period}`;
 }
 
-function clearUsageStatuses(presentation: UsageStatusPresentation): void {
-	for (const period of ["day", "week", "month", "year"] as const) {
-		presentation.setStatus(getUsageStatusKey(period), undefined);
-	}
-}
-
 export function createUsageRefresher(options: UsageRefresherOptions) {
 	const now = options.now ?? (() => new Date());
 	let running = false;
@@ -93,12 +87,7 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 	return {
 		refresh(access: KiloAccess, presentation: UsageStatusPresentation): void {
 			const periods = getRequestedUsagePeriods();
-			if (periods.length === 0) {
-				revision += 1;
-				queued = undefined;
-				clearUsageStatuses(presentation);
-				return;
-			}
+			if (periods.length === 0) return;
 
 			revision += 1;
 			const request = { access, periods, presentation, revision };
@@ -109,11 +98,6 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 
 			running = true;
 			void run(request);
-		},
-		clear(presentation: UsageStatusPresentation): void {
-			revision += 1;
-			queued = undefined;
-			clearUsageStatuses(presentation);
 		},
 	};
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,119 @@
+import type { KiloAccess, KiloUsageEntry, KiloUsageFetchPeriod } from "./api.ts";
+
+export type KiloUsageDisplayPeriod = "day" | "week" | "month" | "year";
+
+const USAGE_STATUS_PREFIX = "kilo-usage-";
+
+export interface UsageStatusPresentation {
+	setStatus(key: string, value: string | undefined): void;
+	accent(text: string): string;
+}
+
+interface UsageRefreshRequest {
+	access: KiloAccess;
+	periods: KiloUsageDisplayPeriod[];
+	presentation: UsageStatusPresentation;
+	revision: number;
+}
+
+interface UsageRefresherOptions {
+	fetchUsageEntries(access: KiloAccess, period: KiloUsageFetchPeriod): Promise<KiloUsageEntry[] | null>;
+	now?(): Date;
+}
+
+export function getRequestedUsagePeriods(): KiloUsageDisplayPeriod[] {
+	const value = process.env.KILO_USAGE?.trim().toLowerCase();
+	return ["1", "true", "yes", "day"].includes(value ?? "") ? ["day"] : [];
+}
+
+export function getUsageFetchPeriod(periods: KiloUsageDisplayPeriod[]): KiloUsageFetchPeriod {
+	if (periods.includes("year")) return "year";
+	if (periods.includes("month")) return "month";
+	return "week";
+}
+
+export function sumUsageForDay(entries: KiloUsageEntry[], date: Date): number {
+	const today = date.toISOString().slice(0, 10);
+	return entries
+		.filter((entry) => entry.date === today)
+		.reduce((total, entry) => total + entry.totalCostMicrodollars, 0);
+}
+
+function sumUsage(entries: KiloUsageEntry[]): number {
+	return entries.reduce((total, entry) => total + entry.totalCostMicrodollars, 0);
+}
+
+function formatUsage(microdollars: number, period: KiloUsageDisplayPeriod): string {
+	const label =
+		period === "day" ? "today" : period === "week" ? "this week" : period === "month" ? "this month" : "this year";
+	return `💸 $${(microdollars / 1_000_000).toFixed(2)} ${label}`;
+}
+
+function getUsageStatusKey(period: KiloUsageDisplayPeriod): string {
+	return `${USAGE_STATUS_PREFIX}${period}`;
+}
+
+function clearUsageStatuses(presentation: UsageStatusPresentation): void {
+	for (const period of ["day", "week", "month", "year"] as const) {
+		presentation.setStatus(getUsageStatusKey(period), undefined);
+	}
+}
+
+export function createUsageRefresher(options: UsageRefresherOptions) {
+	const now = options.now ?? (() => new Date());
+	let running = false;
+	let queued: UsageRefreshRequest | undefined;
+	let revision = 0;
+
+	async function run(request: UsageRefreshRequest): Promise<void> {
+		try {
+			const entries = await options.fetchUsageEntries(request.access, getUsageFetchPeriod(request.periods));
+			if (!entries || request.revision !== revision) return;
+
+			for (const period of request.periods) {
+				const spend = period === "day" ? sumUsageForDay(entries, now()) : sumUsage(entries);
+				request.presentation.setStatus(
+					getUsageStatusKey(period),
+					request.presentation.accent(formatUsage(spend, period)),
+				);
+			}
+		} catch {
+			// Usage is a background status; never let it reject a Pi lifecycle handler.
+		} finally {
+			if (queued) {
+				const next = queued;
+				queued = undefined;
+				void run(next);
+			} else {
+				running = false;
+			}
+		}
+	}
+
+	return {
+		refresh(access: KiloAccess, presentation: UsageStatusPresentation): void {
+			const periods = getRequestedUsagePeriods();
+			if (periods.length === 0) {
+				revision += 1;
+				queued = undefined;
+				clearUsageStatuses(presentation);
+				return;
+			}
+
+			revision += 1;
+			const request = { access, periods, presentation, revision };
+			if (running) {
+				queued = request;
+				return;
+			}
+
+			running = true;
+			void run(request);
+		},
+		clear(presentation: UsageStatusPresentation): void {
+			revision += 1;
+			queued = undefined;
+			clearUsageStatuses(presentation);
+		},
+	};
+}

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
 	fetchKiloBalance,
 	fetchKiloProfile,
+	fetchKiloUsageEntries,
 	KILO_API_BASE,
 	KILO_ORG_HEADER,
 	withOrganizationHeader,
@@ -89,6 +90,61 @@ describe("fetchKiloProfile", () => {
 		vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockRejectedValue(error));
 
 		await expect(fetchKiloProfile("access-token")).rejects.toBe(error);
+	});
+});
+
+describe("fetchKiloUsageEntries", () => {
+	test("requests weekly personal usage and normalizes valid rows", async () => {
+		const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					usage: [
+						{ date: "2026-08-22", total_cost: 1_250_000 },
+						{ date: "invalid", total_cost: 10 },
+						{ date: "2026-08-21", total_cost: "bad" },
+					],
+				}),
+				{ status: 200 },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(fetchKiloUsageEntries({ token: "access-token" }, "week")).resolves.toEqual([
+			{ date: "2026-08-22", totalCostMicrodollars: 1_250_000 },
+		]);
+		expect(fetchMock).toHaveBeenCalledWith(
+			`${KILO_API_BASE}/api/profile/usage?period=week&viewType=personal`,
+			expect.objectContaining({ headers: { Authorization: "Bearer access-token" } }),
+		);
+	});
+
+	test("requests organization usage with its view and header", async () => {
+		const fetchMock = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response(JSON.stringify({ usage: [] }), { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await fetchKiloUsageEntries({ token: "access-token", organizationId: "organization-id" }, "month");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			`${KILO_API_BASE}/api/profile/usage?period=month&viewType=organization-id`,
+			expect.objectContaining({
+				headers: {
+					Authorization: "Bearer access-token",
+					"X-KiloCode-OrganizationId": "organization-id",
+				},
+			}),
+		);
+	});
+
+	test.each([
+		["a non-OK response", () => Promise.resolve(new Response(null, { status: 503 }))],
+		["a malformed payload", () => Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))],
+		["a network error", () => Promise.reject(new Error("network failure"))],
+	])("returns null for %s", async (_name, response) => {
+		vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockImplementation(response));
+
+		await expect(fetchKiloUsageEntries({ token: "access-token" }, "week")).resolves.toBeNull();
 	});
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -16,6 +16,7 @@ beforeEach(() => {
 	vi.stubEnv("KILO_ORG_ID", "");
 	vi.stubEnv("KILOCODE_ORGANIZATION_ID", "");
 	vi.stubEnv("KILO_CUSTOM_FOOTER", "0");
+	vi.stubEnv("KILO_USAGE", "");
 });
 
 afterEach(() => {
@@ -216,13 +217,19 @@ function handler(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler 
 	return registered;
 }
 
-function createRuntime(options: { auth?: object; apiKey?: string; organizationId?: string; balance?: number } = {}) {
+function createRuntime(
+	options: { auth?: object; apiKey?: string; organizationId?: string; balance?: number; usage?: unknown } = {},
+) {
 	if (options.auth) setAuth(options.auth);
 	vi.stubEnv("KILO_API_KEY", options.apiKey ?? "");
 	vi.stubEnv("KILO_ORG_ID", options.organizationId ?? "");
 	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
-		if (String(input).endsWith("/balance")) {
+		const url = String(input);
+		if (url.endsWith("/balance")) {
 			return new Response(JSON.stringify({ balance: options.balance ?? 12.34 }), { status: 200 });
+		}
+		if (url.includes("/usage?")) {
+			return new Response(JSON.stringify(options.usage ?? { usage: [] }), { status: 200 });
 		}
 		return catalogResponse();
 	});
@@ -344,6 +351,80 @@ test.each([
 	const beforeAgentStart = handler(runtime.on, "before_agent_start");
 	await expect(beforeAgentStart({}, { model: { provider: "kilo" } })).resolves.toEqual(expected);
 	await expect(beforeAgentStart({}, { model: { provider: "kilo" } })).resolves.toBeUndefined();
+});
+
+test("does not request usage or set a usage status by default", async () => {
+	const runtime = createRuntime({ apiKey: "api-key" });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "session_start")({}, runtime.context);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(false);
+	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-usage-day", expect.anything());
+});
+
+test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes", async (value) => {
+	vi.stubEnv("KILO_USAGE", value);
+	const runtime = createRuntime({
+		apiKey: "api-key",
+		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 1_234_567 }] },
+	});
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "session_start")({}, runtime.context);
+
+	await vi.waitFor(() => {
+		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $1.23 today");
+	});
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?period=week"))).toBe(true);
+});
+
+test("turn_end schedules an enabled daily usage refresh", async () => {
+	vi.stubEnv("KILO_USAGE", "day");
+	const runtime = createRuntime({
+		apiKey: "api-key",
+		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 2_000_000 }] },
+	});
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+
+	await vi.waitFor(() => {
+		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $2.00 today");
+	});
+});
+
+test("custom footer renders the opt-in daily usage status", async () => {
+	vi.stubEnv("KILO_CUSTOM_FOOTER", "1");
+	const runtime = createRuntime();
+	const setFooter = vi.fn();
+	const statuses = new Map([["kilo-usage-day", "💸 $1.23 today"]]);
+	const context = {
+		...runtime.context,
+		ui: { ...runtime.context.ui, setFooter },
+		sessionManager: { getEntries: () => [], getSessionName: () => undefined },
+		getContextUsage: () => null,
+		modelRegistry: { ...runtime.context.modelRegistry, isUsingOAuth: () => false },
+	};
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	const sessionStartHandlers = runtime.on.mock.calls
+		.filter(([event]) => event === "session_start")
+		.map(([, registered]) => registered as ExtensionHandler);
+	await Promise.all(sessionStartHandlers.map((registered) => registered({}, context)));
+
+	const footer = setFooter.mock.calls[0]?.[0](
+		{ requestRender: vi.fn() },
+		{ fg: vi.fn((_tone, text) => text) },
+		{
+			onBranchChange: () => vi.fn(),
+			getGitBranch: () => undefined,
+			getExtensionStatuses: () => statuses,
+			getAvailableProviderCount: () => 1,
+		},
+	);
+	expect(footer.render(200)[1]).toContain("💸 $1.23 today");
 });
 
 test("before_agent_start does not consume the notice for another provider", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -33,6 +33,14 @@ function setAuth(auth: object): void {
 	writeFileSync(join(agentDirectory, "auth.json"), JSON.stringify(auth));
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
 const catalogResponse = () =>
 	new Response(
 		JSON.stringify({
@@ -218,7 +226,14 @@ function handler(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler 
 }
 
 function createRuntime(
-	options: { auth?: object; apiKey?: string; organizationId?: string; balance?: number; usage?: unknown } = {},
+	options: {
+		auth?: object;
+		apiKey?: string;
+		organizationId?: string;
+		balance?: number;
+		usage?: unknown;
+		usageResponse?: Promise<Response>;
+	} = {},
 ) {
 	if (options.auth) setAuth(options.auth);
 	vi.stubEnv("KILO_API_KEY", options.apiKey ?? "");
@@ -229,7 +244,7 @@ function createRuntime(
 			return new Response(JSON.stringify({ balance: options.balance ?? 12.34 }), { status: 200 });
 		}
 		if (url.includes("/usage?")) {
-			return new Response(JSON.stringify(options.usage ?? { usage: [] }), { status: 200 });
+			return options.usageResponse ?? new Response(JSON.stringify(options.usage ?? { usage: [] }), { status: 200 });
 		}
 		return catalogResponse();
 	});
@@ -392,6 +407,26 @@ test("turn_end schedules an enabled daily usage refresh", async () => {
 
 	await vi.waitFor(() => {
 		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $2.00 today");
+	});
+});
+
+test("turn_end does not wait for an enabled usage response", async () => {
+	vi.stubEnv("KILO_USAGE", "day");
+	const usageResponse = deferred<Response>();
+	const runtime = createRuntime({ apiKey: "api-key", usageResponse: usageResponse.promise });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await expect(handler(runtime.on, "turn_end")({}, runtime.context)).resolves.toBeUndefined();
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(true);
+
+	usageResponse.resolve(
+		new Response(
+			JSON.stringify({ usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 3_000_000 }] }),
+			{ status: 200 },
+		),
+	);
+	await vi.waitFor(() => {
+		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $3.00 today");
 	});
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -379,6 +379,16 @@ test("does not request usage or set a usage status by default", async () => {
 	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-usage-day", expect.anything());
 });
 
+test("clears enabled daily usage when access is unavailable", async () => {
+	vi.stubEnv("KILO_USAGE", "day");
+	const runtime = createRuntime();
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "session_start")({}, runtime.context);
+
+	expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", undefined);
+});
+
 test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes", async (value) => {
 	vi.stubEnv("KILO_USAGE", value);
 	const runtime = createRuntime({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -379,16 +379,6 @@ test("does not request usage or set a usage status by default", async () => {
 	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-usage-day", expect.anything());
 });
 
-test("clears enabled daily usage when access is unavailable", async () => {
-	vi.stubEnv("KILO_USAGE", "day");
-	const runtime = createRuntime();
-
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
-	await handler(runtime.on, "session_start")({}, runtime.context);
-
-	expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", undefined);
-});
-
 test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes", async (value) => {
 	vi.stubEnv("KILO_USAGE", value);
 	const runtime = createRuntime({

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -69,18 +69,6 @@ describe("createUsageRefresher", () => {
 		expect(fetchUsageEntries).toHaveBeenCalledWith(access, "week");
 	});
 
-	test("clears usage when it is disabled", () => {
-		const setStatus = vi.fn();
-		const refresher = createUsageRefresher({
-			fetchUsageEntries: vi.fn(),
-			now: () => today,
-		});
-
-		refresher.refresh(access, { setStatus, accent: (text) => text });
-
-		expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", undefined);
-	});
-
 	test("coalesces active refreshes and applies only the most recent result", async () => {
 		vi.stubEnv("KILO_USAGE", "1");
 		const first = deferred<KiloUsageEntry[] | null>();

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { KiloAccess, KiloUsageEntry } from "../src/api.ts";
+import { createUsageRefresher, getRequestedUsagePeriods, getUsageFetchPeriod, sumUsageForDay } from "../src/usage.ts";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	vi.restoreAllMocks();
+});
+
+const access: KiloAccess = { token: "access-token" };
+const today = new Date("2026-08-22T12:00:00.000Z");
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+describe("getRequestedUsagePeriods", () => {
+	test.each(["1", "true", "TRUE", "yes", " day "])("enables daily usage for %j", (value) => {
+		vi.stubEnv("KILO_USAGE", value);
+
+		expect(getRequestedUsagePeriods()).toEqual(["day"]);
+	});
+
+	test.each([undefined, "", "0", "false", "no", "week", "unexpected"])("disables usage for %j", (value) => {
+		if (value === undefined) {
+			vi.stubEnv("KILO_USAGE", "");
+		} else {
+			vi.stubEnv("KILO_USAGE", value);
+		}
+
+		expect(getRequestedUsagePeriods()).toEqual([]);
+	});
+});
+
+describe("getUsageFetchPeriod", () => {
+	test("uses a rolling week for daily usage because the API has no day period", () => {
+		expect(getUsageFetchPeriod(["day"])).toBe("week");
+	});
+});
+
+describe("sumUsageForDay", () => {
+	test("sums only rows for the requested UTC date", () => {
+		const entries: KiloUsageEntry[] = [
+			{ date: "2026-08-22", totalCostMicrodollars: 1_250_000 },
+			{ date: "2026-08-22", totalCostMicrodollars: 750_000 },
+			{ date: "2026-08-21", totalCostMicrodollars: 9_000_000 },
+		];
+
+		expect(sumUsageForDay(entries, today)).toBe(2_000_000);
+	});
+});
+
+describe("createUsageRefresher", () => {
+	test("publishes the daily status after a background refresh", async () => {
+		vi.stubEnv("KILO_USAGE", "day");
+		const fetchUsageEntries = vi.fn().mockResolvedValue([{ date: "2026-08-22", totalCostMicrodollars: 1_234_567 }]);
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
+
+		refresher.refresh(access, { setStatus, accent: (text) => text });
+
+		await vi.waitFor(() => {
+			expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $1.23 today");
+		});
+		expect(fetchUsageEntries).toHaveBeenCalledWith(access, "week");
+	});
+
+	test("clears usage when it is disabled", () => {
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({
+			fetchUsageEntries: vi.fn(),
+			now: () => today,
+		});
+
+		refresher.refresh(access, { setStatus, accent: (text) => text });
+
+		expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", undefined);
+	});
+
+	test("coalesces active refreshes and applies only the most recent result", async () => {
+		vi.stubEnv("KILO_USAGE", "1");
+		const first = deferred<KiloUsageEntry[] | null>();
+		const second = deferred<KiloUsageEntry[] | null>();
+		const fetchUsageEntries = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
+		const presentation = { setStatus, accent: (text: string) => text };
+
+		refresher.refresh(access, presentation);
+		refresher.refresh({ token: "newest-token" }, presentation);
+		refresher.refresh({ token: "newest-token" }, presentation);
+
+		expect(fetchUsageEntries).toHaveBeenCalledTimes(1);
+		first.resolve([{ date: "2026-08-22", totalCostMicrodollars: 1_000_000 }]);
+		await vi.waitFor(() => expect(fetchUsageEntries).toHaveBeenCalledTimes(2));
+		expect(setStatus).not.toHaveBeenCalledWith("kilo-usage-day", "💸 $1.00 today");
+
+		second.resolve([{ date: "2026-08-22", totalCostMicrodollars: 2_000_000 }]);
+		await vi.waitFor(() => {
+			expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $2.00 today");
+		});
+		expect(fetchUsageEntries).toHaveBeenLastCalledWith({ token: "newest-token" }, "week");
+	});
+});


### PR DESCRIPTION
Adds opt-in daily Kilo usage reporting.

- Enable with `KILO_USAGE=1` (`true`, `yes`, and `day` also work).
- Fetches rolling weekly usage data and derives today’s spend locally.
- Displays `kilo-usage-day` in the Kilo footer after credits.
- Refreshes asynchronously at session start and after turns without blocking Pi.
- Coalesces overlapping refreshes to one active request plus one latest follow-up.
- Extracts usage fetching/normalization into `src/api.ts` and usage policy into `src/usage.ts`.

Squash-merge after the review.
