### PR TITLE
feat: make footer credits configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Kilo replaces Pi's footer by default to show usage and credits. To keep another 
 KILO_CUSTOM_FOOTER=0 pi
 ```
 
-Kilo credits remain available as the `kilo-credits` footer status.
+Kilo credits are shown by default and remain available as the `kilo-credits` footer status. To hide them and avoid balance requests, set `KILO_SHOW_CREDITS=0`:
+
+```bash
+KILO_SHOW_CREDITS=0 pi
+```
 
 To show today's Kilo spend, opt in to usage status reporting:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,12 @@ export function usesCustomFooter(): boolean {
 	return !["0", "false", "no"].includes(value ?? "");
 }
 
+/** Whether to fetch and display the Kilo credit balance in the footer. */
+export function showsCredits(): boolean {
+	const value = process.env.KILO_SHOW_CREDITS?.trim().toLowerCase();
+	return !["0", "false", "no"].includes(value ?? "");
+}
+
 function formatCredits(balance: number): string {
 	if (balance >= 1000) {
 		return `$${(balance / 1000).toFixed(1)}k`;
@@ -128,6 +134,8 @@ function makeProviderConfig(organizationId?: string) {
 
 export default async function (pi: ExtensionAPI) {
 	const startupAccess = getKiloAccess();
+	// Environment configuration is read once at extension startup.
+	const creditsEnabled = showsCredits();
 
 	// Fetch models at load time so the provider is immediately usable for
 	// --list-models, --model selection, and print mode before session_start fires.
@@ -218,9 +226,9 @@ export default async function (pi: ExtensionAPI) {
 		const access = getKiloAccess();
 		const usageEnabled = getRequestedUsagePeriods().length > 0;
 
-		// Clear credits if not logged in.
+		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
-			ctx.ui.setStatus("kilo-credits", undefined);
+			if (ctx.hasUI) ctx.ui.setStatus("kilo-credits", undefined);
 			return;
 		}
 
@@ -252,8 +260,8 @@ export default async function (pi: ExtensionAPI) {
 			});
 		}
 
-		// Fetch and display credits balance when an interactive UI is available.
-		if (ctx.hasUI) {
+		// Fetch and display credits balance when enabled and an interactive UI is available.
+		if (ctx.hasUI && creditsEnabled) {
 			try {
 				const balance = await fetchKiloBalance(access.token, access.organizationId);
 				if (balance !== null) {
@@ -273,7 +281,7 @@ export default async function (pi: ExtensionAPI) {
 		const access = getKiloAccess();
 		if (!access) return;
 
-		if (!ctx.hasUI) return;
+		if (!ctx.hasUI || !creditsEnabled) return;
 
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -301,6 +309,8 @@ export default async function (pi: ExtensionAPI) {
 				accent: (text) => ctx.ui.theme.fg("accent", text),
 			});
 		}
+
+		if (!creditsEnabled) return;
 
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -426,10 +436,10 @@ export default async function (pi: ExtensionAPI) {
 						}
 						statsParts.push(contextPercentStr);
 
-						// Inject credits inline on the main stats line
+						// Inject enabled Kilo statuses inline on the main stats line
 						const extensionStatuses = footerData.getExtensionStatuses();
 						const creditsStatus = extensionStatuses.get("kilo-credits");
-						if (creditsStatus) statsParts.push(creditsStatus);
+						if (creditsEnabled && creditsStatus) statsParts.push(creditsStatus);
 						for (const period of ["day", "week", "month", "year"]) {
 							const usageStatus = extensionStatuses.get(`kilo-usage-${period}`);
 							if (usageStatus) statsParts.push(usageStatus);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import kiloExtension, { parsePrice, usesCustomFooter } from "../src/index.ts";
+import kiloExtension, { parsePrice, showsCredits, usesCustomFooter } from "../src/index.ts";
 
 const temporaryDirectories: string[] = [];
 let agentDirectory: string;
@@ -16,6 +16,7 @@ beforeEach(() => {
 	vi.stubEnv("KILO_ORG_ID", "");
 	vi.stubEnv("KILOCODE_ORGANIZATION_ID", "");
 	vi.stubEnv("KILO_CUSTOM_FOOTER", "0");
+	vi.stubEnv("KILO_SHOW_CREDITS", "");
 	vi.stubEnv("KILO_USAGE", "");
 });
 
@@ -81,6 +82,25 @@ test.each([
 	expect(usesCustomFooter()).toBe(expected);
 });
 
+test.each([
+	[undefined, true],
+	["1", true],
+	["true", true],
+	["unexpected", true],
+	["0", false],
+	["false", false],
+	["FALSE", false],
+	[" no ", false],
+])("showsCredits returns %s for KILO_SHOW_CREDITS=%s", (value, expected) => {
+	if (value === undefined) {
+		vi.stubEnv("KILO_SHOW_CREDITS", undefined);
+	} else {
+		vi.stubEnv("KILO_SHOW_CREDITS", value);
+	}
+
+	expect(showsCredits()).toBe(expected);
+});
+
 test("parsePrice returns zero for an invalid price", () => {
 	expect(parsePrice("not-a-number")).toBe(0);
 });
@@ -141,6 +161,19 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 
 	expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
 	expect(context.ui.setFooter).not.toHaveBeenCalled();
+});
+
+test("does not fetch or display credits when KILO_SHOW_CREDITS is disabled", async () => {
+	vi.stubEnv("KILO_SHOW_CREDITS", "false");
+	const runtime = createRuntime({ apiKey: "api-key" });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "session_start")({}, runtime.context);
+	await handler(runtime.on, "model_select")({ model: { provider: "kilo" } }, runtime.context);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).endsWith("/balance"))).toBe(false);
+	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-credits", expect.anything());
 });
 
 test("registers anonymous free models from the Kilo catalog", async () => {


### PR DESCRIPTION
Adds `KILO_SHOW_CREDITS` to control whether the Kilo credit balance appears in the footer.

- Credits remain shown by default.
- Set `KILO_SHOW_CREDITS=0` (also false or no) to hide credits and skip balance API requests.
- Snapshots the setting at extension startup for consistent behavior.
- Documents the option and adds test coverage.
