### PR TITLE
feat: add Kilo preference configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+## [2026.08.1] - 2026-08-29
+
+### Added
+
+- Add global and trusted-project preference files for footer, credits, and usage reporting ([#21](https://github.com/Kilo-Org/kilo-pi-provider/pull/21)).
+- Support daily, weekly, monthly, and yearly usage statuses ([#21](https://github.com/Kilo-Org/kilo-pi-provider/pull/21)).
+
+### Changed
+
+- Support comma-separated usage periods in configuration and `KILO_USAGE`, for example `day,week` ([#21](https://github.com/Kilo-Org/kilo-pi-provider/pull/21)).
+
 ## [2026.08.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,13 +63,27 @@ Kilo credits are shown by default and remain available as the `kilo-credits` foo
 KILO_SHOW_CREDITS=0 pi
 ```
 
-To show today's Kilo spend, opt in to usage status reporting:
+### Preferences
 
-```bash
-KILO_USAGE=1 pi
+Set non-secret preferences globally in `~/.pi/agent/extensions/kilo-pi-provider/config.json`, or per trusted project in `.pi/extensions/kilo-pi-provider/config.json`:
+
+```json
+{
+  "footer": { "custom": false },
+  "credits": { "enabled": true },
+  "usage": { "periods": ["day", "week"] }
+}
 ```
 
-`KILO_USAGE` also accepts `true`, `yes`, or `day`. Daily usage refreshes at session start and after completed turns.
+A trusted project file overrides the global file, and environment variables override both. Project preferences are ignored until Pi trusts the project. Keep API keys and OAuth credentials out of these files.
+
+Environment overrides are useful for one-off sessions:
+
+```bash
+KILO_USAGE=day,week pi
+```
+
+`KILO_USAGE` accepts comma-separated periods; `1`, `true`, and `yes` remain shorthand for `day`. Usage refreshes at session start and after completed turns.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.0",
+  "version": "2026.08.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilocode/kilo-pi-provider",
-      "version": "2026.08.0",
+      "version": "2026.08.1",
       "license": "BSL-1.0",
       "devDependencies": {
         "@biomejs/biome": "2.3.5",
-        "@earendil-works/pi-tui": "0.84.2",
+        "@earendil-works/pi-tui": "0.84.4",
         "@j178/prek": "0.4.14",
         "@vitest/coverage-v8": "4.1.9",
         "vitest": "4.1.9"
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.2",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.2.tgz",
-      "integrity": "sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==",
+      "version": "0.84.4",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.4.tgz",
+      "integrity": "sha512-nPUnwDkLtupPXnZQYrCwPFcuTydCDqTY6ZbFqhsL4S4kVq0AT418kPa/6uXwtaCD+MjBNBltb7ScTYX65yeE1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.0",
+  "version": "2026.08.1",
   "type": "module",
   "keywords": ["pi-package"],
   "license": "BSL-1.0",
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.5",
-    "@earendil-works/pi-tui": "0.84.2",
+    "@earendil-works/pi-tui": "0.84.4",
     "@j178/prek": "0.4.14",
     "@vitest/coverage-v8": "4.1.9",
     "vitest": "4.1.9"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const KILO_USAGE_PERIODS = ["day", "week", "month", "year"] as const;
+export type KiloUsageDisplayPeriod = (typeof KILO_USAGE_PERIODS)[number];
+
+export type KiloPreferences = {
+	footer?: { custom?: boolean };
+	credits?: { enabled?: boolean };
+	usage?: { periods?: KiloUsageDisplayPeriod[] };
+};
+
+export type ResolvedKiloPreferences = {
+	footer: { custom: boolean };
+	credits: { enabled: boolean };
+	usage: { periods: KiloUsageDisplayPeriod[] };
+};
+
+const CONFIG_DIRECTORY = "kilo-pi-provider";
+const DEFAULT_PREFERENCES: ResolvedKiloPreferences = {
+	footer: { custom: true },
+	credits: { enabled: true },
+	usage: { periods: [] },
+};
+
+function isUsagePeriod(value: unknown): value is KiloUsageDisplayPeriod {
+	return typeof value === "string" && KILO_USAGE_PERIODS.includes(value as KiloUsageDisplayPeriod);
+}
+
+type PreferencesObject = {
+	footer?: unknown;
+	credits?: unknown;
+	usage?: unknown;
+};
+
+function isPreferencesObject(value: unknown): value is PreferencesObject {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readKiloPreferences(path: string): KiloPreferences {
+	if (!existsSync(path)) return {};
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+		if (!isPreferencesObject(parsed)) return {};
+		const footer = isPreferencesObject(parsed.footer) ? parsed.footer : undefined;
+		const credits = isPreferencesObject(parsed.credits) ? parsed.credits : undefined;
+		const usage = isPreferencesObject(parsed.usage) ? parsed.usage : undefined;
+		return {
+			footer: typeof footer?.custom === "boolean" ? { custom: footer.custom } : undefined,
+			credits: typeof credits?.enabled === "boolean" ? { enabled: credits.enabled } : undefined,
+			usage:
+				Array.isArray(usage?.periods) && usage.periods.every(isUsagePeriod)
+					? { periods: usage.periods }
+					: undefined,
+		};
+	} catch {
+		return {};
+	}
+}
+
+function getConfigPath(root: string): string {
+	return join(root, "extensions", CONFIG_DIRECTORY, "config.json");
+}
+
+function environmentBoolean(value: string | undefined, defaultValue: boolean): boolean | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "") return undefined;
+	if (["1", "true", "yes"].includes(normalized)) return true;
+	if (["0", "false", "no"].includes(normalized)) return false;
+	return defaultValue;
+}
+
+function environmentUsagePeriods(value: string | undefined): KiloUsageDisplayPeriod[] | undefined {
+	if (value === undefined) return undefined;
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "") return undefined;
+	if (["1", "true", "yes"].includes(normalized)) return ["day"];
+	if (["0", "false", "no"].includes(normalized)) return [];
+	const periods = normalized
+		.split(",")
+		.map((period) => period.trim())
+		.filter(Boolean);
+	return periods.length > 0 && periods.every(isUsagePeriod) ? [...new Set(periods)] : [];
+}
+
+export function getEnvironmentPreferences(environment: NodeJS.ProcessEnv = process.env): KiloPreferences {
+	return {
+		footer: { custom: environmentBoolean(environment.KILO_CUSTOM_FOOTER, true) },
+		credits: { enabled: environmentBoolean(environment.KILO_SHOW_CREDITS, true) },
+		usage: { periods: environmentUsagePeriods(environment.KILO_USAGE) },
+	};
+}
+
+export function mergeKiloPreferences(
+	global: KiloPreferences,
+	project: KiloPreferences | undefined,
+	environment: KiloPreferences,
+): ResolvedKiloPreferences {
+	return {
+		footer: {
+			custom:
+				environment.footer?.custom ??
+				project?.footer?.custom ??
+				global.footer?.custom ??
+				DEFAULT_PREFERENCES.footer.custom,
+		},
+		credits: {
+			enabled:
+				environment.credits?.enabled ??
+				project?.credits?.enabled ??
+				global.credits?.enabled ??
+				DEFAULT_PREFERENCES.credits.enabled,
+		},
+		usage: {
+			periods:
+				environment.usage?.periods ??
+				project?.usage?.periods ??
+				global.usage?.periods ??
+				DEFAULT_PREFERENCES.usage.periods,
+		},
+	};
+}
+
+export function loadKiloPreferences(options: {
+	agentDirectory?: string;
+	cwd: string;
+	projectTrusted: boolean;
+	environment?: NodeJS.ProcessEnv;
+}): ResolvedKiloPreferences {
+	const agentDirectory = options.agentDirectory ?? process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+	const global = readKiloPreferences(getConfigPath(agentDirectory));
+	const project = options.projectTrusted ? readKiloPreferences(getConfigPath(join(options.cwd, ".pi"))) : undefined;
+	return mergeKiloPreferences(global, project, getEnvironmentPreferences(options.environment));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,10 @@ import {
 	loginKilo,
 	refreshKiloToken,
 } from "./auth.ts";
-import { installCustomFooter, usesCustomFooter } from "./footer.ts";
+import { loadKiloPreferences } from "./config.ts";
+import { installCustomFooter } from "./footer.ts";
 
-import { createUsageRefresher, getRequestedUsagePeriods } from "./usage.ts";
+import { createUsageRefresher } from "./usage.ts";
 
 // =============================================================================
 // Constants
@@ -40,12 +41,6 @@ import { createUsageRefresher, getRequestedUsagePeriods } from "./usage.ts";
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const KILO_TOS_URL = "https://kilo.ai/terms";
-
-/** Whether to fetch and display the Kilo credit balance in the footer. */
-export function showsCredits(): boolean {
-	const value = process.env.KILO_SHOW_CREDITS?.trim().toLowerCase();
-	return !["0", "false", "no"].includes(value ?? "");
-}
 
 function formatCredits(balance: number): string {
 	if (balance >= 1000) {
@@ -130,8 +125,7 @@ function makeProviderConfig(organizationId?: string) {
 
 export default async function (pi: ExtensionAPI) {
 	const startupAccess = getKiloAccess();
-	// Environment configuration is read once at extension startup.
-	const creditsEnabled = showsCredits();
+	let preferences = loadKiloPreferences({ cwd: process.cwd(), projectTrusted: false });
 
 	// Fetch models at load time so the provider is immediately usable for
 	// --list-models, --model selection, and print mode before session_start fires.
@@ -219,8 +213,12 @@ export default async function (pi: ExtensionAPI) {
 	// After session starts, pre-fetch all models if already logged in so
 	// modifyModels has data to work with. Also fetch and display credits.
 	pi.on("session_start", async (_event, ctx) => {
+		preferences = loadKiloPreferences({
+			cwd: ctx.cwd ?? process.cwd(),
+			projectTrusted: ctx.isProjectTrusted?.() ?? false,
+		});
 		const access = getKiloAccess();
-		const usageEnabled = getRequestedUsagePeriods().length > 0;
+		const usagePeriods = preferences.usage.periods;
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
@@ -228,8 +226,8 @@ export default async function (pi: ExtensionAPI) {
 			return;
 		}
 
-		if (ctx.hasUI && usageEnabled) {
-			usageRefresher.refresh(access, {
+		if (ctx.hasUI && usagePeriods.length > 0) {
+			usageRefresher.refresh(access, usagePeriods, {
 				setStatus: (key, value) => ctx.ui.setStatus(key, value),
 				accent: (text) => ctx.ui.theme.fg("accent", text),
 			});
@@ -257,7 +255,7 @@ export default async function (pi: ExtensionAPI) {
 		}
 
 		// Fetch and display credits balance when enabled and an interactive UI is available.
-		if (ctx.hasUI && creditsEnabled) {
+		if (ctx.hasUI && preferences.credits.enabled) {
 			try {
 				const balance = await fetchKiloBalance(access.token, access.organizationId);
 				if (balance !== null) {
@@ -277,7 +275,7 @@ export default async function (pi: ExtensionAPI) {
 		const access = getKiloAccess();
 		if (!access) return;
 
-		if (!ctx.hasUI || !creditsEnabled) return;
+		if (!ctx.hasUI || !preferences.credits.enabled) return;
 
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -296,17 +294,17 @@ export default async function (pi: ExtensionAPI) {
 	// Refresh credits and opt-in usage after each turn.
 	pi.on("turn_end", async (_event, ctx) => {
 		const access = getKiloAccess();
-		const usageEnabled = getRequestedUsagePeriods().length > 0;
+		const usagePeriods = preferences.usage.periods;
 		if (!access || !ctx.hasUI) return;
 
-		if (usageEnabled) {
-			usageRefresher.refresh(access, {
+		if (usagePeriods.length > 0) {
+			usageRefresher.refresh(access, usagePeriods, {
 				setStatus: (key, value) => ctx.ui.setStatus(key, value),
 				accent: (text) => ctx.ui.theme.fg("accent", text),
 			});
 		}
 
-		if (!creditsEnabled) return;
+		if (!preferences.credits.enabled) return;
 
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -342,11 +340,7 @@ export default async function (pi: ExtensionAPI) {
 		};
 	});
 
-	// Use custom footer to show credits inline with token stats.
-	// Disable it with KILO_CUSTOM_FOOTER=0 to allow another extension's footer.
-	if (usesCustomFooter()) {
-		pi.on("session_start", async (_event, ctx) => {
-			installCustomFooter(pi, ctx, creditsEnabled);
-		});
-	}
+	pi.on("session_start", async (_event, ctx) => {
+		if (preferences.footer.custom) installCustomFooter(pi, ctx, preferences.credits.enabled);
+	});
 }

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,6 +1,7 @@
 import type { KiloAccess, KiloUsageEntry, KiloUsageFetchPeriod } from "./api.ts";
+import type { KiloUsageDisplayPeriod } from "./config.ts";
 
-export type KiloUsageDisplayPeriod = "day" | "week" | "month" | "year";
+export type { KiloUsageDisplayPeriod } from "./config.ts";
 
 const USAGE_STATUS_PREFIX = "kilo-usage-";
 
@@ -19,11 +20,6 @@ interface UsageRefreshRequest {
 interface UsageRefresherOptions {
 	fetchUsageEntries(access: KiloAccess, period: KiloUsageFetchPeriod): Promise<KiloUsageEntry[] | null>;
 	now?(): Date;
-}
-
-export function getRequestedUsagePeriods(): KiloUsageDisplayPeriod[] {
-	const value = process.env.KILO_USAGE?.trim().toLowerCase();
-	return ["1", "true", "yes", "day"].includes(value ?? "") ? ["day"] : [];
 }
 
 export function getUsageFetchPeriod(periods: KiloUsageDisplayPeriod[]): KiloUsageFetchPeriod {
@@ -85,8 +81,7 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 	}
 
 	return {
-		refresh(access: KiloAccess, presentation: UsageStatusPresentation): void {
-			const periods = getRequestedUsagePeriods();
+		refresh(access: KiloAccess, periods: KiloUsageDisplayPeriod[], presentation: UsageStatusPresentation): void {
 			if (periods.length === 0) return;
 
 			revision += 1;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getEnvironmentPreferences, loadKiloPreferences, mergeKiloPreferences } from "../src/config.ts";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+test("merges global, project, and environment preferences in precedence order", () => {
+	expect(
+		mergeKiloPreferences(
+			{ footer: { custom: false }, credits: { enabled: false }, usage: { periods: ["week"] } },
+			{ credits: { enabled: true } },
+			{ credits: { enabled: false }, usage: { periods: ["day", "month"] } },
+		),
+	).toEqual({ footer: { custom: false }, credits: { enabled: false }, usage: { periods: ["day", "month"] } });
+});
+
+test.each([
+	["KILO_USAGE=day,week", { KILO_USAGE: "day,week" }, ["day", "week"]],
+	["legacy truthy KILO_USAGE", { KILO_USAGE: "true" }, ["day"]],
+	["disabled KILO_USAGE", { KILO_USAGE: "0" }, []],
+])("parses %s", (_name, environment, periods) => {
+	expect(getEnvironmentPreferences(environment).usage?.periods).toEqual(periods);
+});
+
+test("uses defaults for unrecognized boolean environment values", () => {
+	expect(getEnvironmentPreferences({ KILO_CUSTOM_FOOTER: "maybe", KILO_SHOW_CREDITS: "unexpected" })).toMatchObject({
+		footer: { custom: true },
+		credits: { enabled: true },
+	});
+});
+
+describe("loadKiloPreferences", () => {
+	function createDirectory(): string {
+		const directory = mkdtempSync(join(tmpdir(), "kilo-config-test-"));
+		temporaryDirectories.push(directory);
+		return directory;
+	}
+
+	function writeConfig(root: string, config: unknown): void {
+		const directory = join(root, "extensions", "kilo-pi-provider");
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(join(directory, "config.json"), typeof config === "string" ? config : JSON.stringify(config));
+	}
+
+	test("uses trusted project preferences over global preferences", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, { credits: { enabled: false }, usage: { periods: ["week"] } });
+		writeConfig(join(cwd, ".pi"), { credits: { enabled: true }, usage: { periods: ["day", "month"] } });
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: true, environment: {} })).toEqual({
+			footer: { custom: true },
+			credits: { enabled: true },
+			usage: { periods: ["day", "month"] },
+		});
+	});
+
+	test("ignores untrusted project preferences and lets environment override config", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, { credits: { enabled: false } });
+		writeConfig(join(cwd, ".pi"), { credits: { enabled: true } });
+
+		expect(
+			loadKiloPreferences({
+				agentDirectory,
+				cwd,
+				projectTrusted: false,
+				environment: { KILO_SHOW_CREDITS: "true", KILO_CUSTOM_FOOTER: "0", KILO_USAGE: "day,week" },
+			}),
+		).toEqual({ footer: { custom: false }, credits: { enabled: true }, usage: { periods: ["day", "week"] } });
+	});
+
+	test("ignores nested values that are not objects", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, { footer: true, credits: [], usage: "day" });
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			footer: { custom: true },
+			credits: { enabled: true },
+			usage: { periods: [] },
+		});
+	});
+
+	test.each(["{", "null", "[]"])("falls back to defaults for invalid config: %s", (config) => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, config);
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			footer: { custom: true },
+			credits: { enabled: true },
+			usage: { periods: [] },
+		});
+	});
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import kiloExtension, { parsePrice, showsCredits } from "../src/index.ts";
+import kiloExtension, { parsePrice } from "../src/index.ts";
 
 const temporaryDirectories: string[] = [];
 let agentDirectory: string;
@@ -62,25 +62,6 @@ const catalogResponse = () =>
 		}),
 		{ status: 200, headers: { "Content-Type": "application/json" } },
 	);
-
-test.each([
-	[undefined, true],
-	["1", true],
-	["true", true],
-	["unexpected", true],
-	["0", false],
-	["false", false],
-	["FALSE", false],
-	[" no ", false],
-])("showsCredits returns %s for KILO_SHOW_CREDITS=%s", (value, expected) => {
-	if (value === undefined) {
-		vi.stubEnv("KILO_SHOW_CREDITS", undefined);
-	} else {
-		vi.stubEnv("KILO_SHOW_CREDITS", value);
-	}
-
-	expect(showsCredits()).toBe(expected);
-});
 
 test("parsePrice returns zero for an invalid price", () => {
 	expect(parsePrice("not-a-number")).toBe(0);
@@ -145,8 +126,10 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 });
 
 test("does not fetch or display credits when KILO_SHOW_CREDITS is disabled", async () => {
-	vi.stubEnv("KILO_SHOW_CREDITS", "false");
 	const runtime = createRuntime({ apiKey: "api-key" });
+	const configDirectory = join(agentDirectory, "extensions", "kilo-pi-provider");
+	mkdirSync(configDirectory, { recursive: true });
+	writeFileSync(join(configDirectory, "config.json"), JSON.stringify({ credits: { enabled: false } }));
 
 	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
 	await handler(runtime.on, "session_start")({}, runtime.context);

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -7,7 +7,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJson = JSON.parse(readFileSync(resolve(repositoryRoot, "package.json"), "utf8"));
 
 test("declares the first calendar-versioned release", () => {
-	expect(packageJson.version).toBe("2026.08.0");
+	expect(packageJson.version).toBe("2026.08.1");
 });
 
 test("declared Pi extension entry points exist", () => {
@@ -16,6 +16,10 @@ test("declared Pi extension entry points exist", () => {
 	for (const extension of packageJson.pi.extensions) {
 		expect(existsSync(resolve(repositoryRoot, extension)), `${extension} does not exist`).toBe(true);
 	}
+});
+
+test("pins the Pi TUI version used by the extension", () => {
+	expect(packageJson.devDependencies["@earendil-works/pi-tui"]).toBe("0.84.4");
 });
 
 test("provides the upstream Pi Biome check", () => {

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,11 +1,6 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { KiloAccess, KiloUsageEntry } from "../src/api.ts";
-import { createUsageRefresher, getRequestedUsagePeriods, getUsageFetchPeriod, sumUsageForDay } from "../src/usage.ts";
-
-afterEach(() => {
-	vi.unstubAllEnvs();
-	vi.restoreAllMocks();
-});
+import { createUsageRefresher, getUsageFetchPeriod, sumUsageForDay } from "../src/usage.ts";
 
 const access: KiloAccess = { token: "access-token" };
 const today = new Date("2026-08-22T12:00:00.000Z");
@@ -18,27 +13,13 @@ function deferred<T>() {
 	return { promise, resolve };
 }
 
-describe("getRequestedUsagePeriods", () => {
-	test.each(["1", "true", "TRUE", "yes", " day "])("enables daily usage for %j", (value) => {
-		vi.stubEnv("KILO_USAGE", value);
-
-		expect(getRequestedUsagePeriods()).toEqual(["day"]);
-	});
-
-	test.each([undefined, "", "0", "false", "no", "week", "unexpected"])("disables usage for %j", (value) => {
-		if (value === undefined) {
-			vi.stubEnv("KILO_USAGE", "");
-		} else {
-			vi.stubEnv("KILO_USAGE", value);
-		}
-
-		expect(getRequestedUsagePeriods()).toEqual([]);
-	});
-});
-
 describe("getUsageFetchPeriod", () => {
-	test("uses a rolling week for daily usage because the API has no day period", () => {
-		expect(getUsageFetchPeriod(["day"])).toBe("week");
+	test.each([
+		[["day"], "week"],
+		[["month"], "month"],
+		[["year"], "year"],
+	])("uses %s for %s usage", (periods, fetchPeriod) => {
+		expect(getUsageFetchPeriod(periods)).toBe(fetchPeriod);
 	});
 });
 
@@ -56,12 +37,11 @@ describe("sumUsageForDay", () => {
 
 describe("createUsageRefresher", () => {
 	test("publishes the daily status after a background refresh", async () => {
-		vi.stubEnv("KILO_USAGE", "day");
 		const fetchUsageEntries = vi.fn().mockResolvedValue([{ date: "2026-08-22", totalCostMicrodollars: 1_234_567 }]);
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
 
-		refresher.refresh(access, { setStatus, accent: (text) => text });
+		refresher.refresh(access, ["day"], { setStatus, accent: (text) => text });
 
 		await vi.waitFor(() => {
 			expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $1.23 today");
@@ -69,8 +49,47 @@ describe("createUsageRefresher", () => {
 		expect(fetchUsageEntries).toHaveBeenCalledWith(access, "week");
 	});
 
+	test.each([
+		["week", "week", "💸 $2.00 this week"],
+		["month", "month", "💸 $2.00 this month"],
+		["year", "year", "💸 $2.00 this year"],
+	] as const)("publishes %s usage from every returned entry", async (period, fetchPeriod, expectedStatus) => {
+		const fetchUsageEntries = vi.fn().mockResolvedValue([
+			{ date: "2026-08-22", totalCostMicrodollars: 1_250_000 },
+			{ date: "2026-08-21", totalCostMicrodollars: 750_000 },
+		]);
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
+
+		refresher.refresh(access, [period], { setStatus, accent: (text) => text });
+
+		await vi.waitFor(() => {
+			expect(setStatus).toHaveBeenCalledWith(`kilo-usage-${period}`, expectedStatus);
+		});
+		expect(fetchUsageEntries).toHaveBeenCalledWith(access, fetchPeriod);
+	});
+
+	test("does not fetch usage for an empty period list", () => {
+		const fetchUsageEntries = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries });
+
+		refresher.refresh(access, [], { setStatus: vi.fn(), accent: (text) => text });
+
+		expect(fetchUsageEntries).not.toHaveBeenCalled();
+	});
+
+	test("does not publish a status when the usage endpoint has no entries", async () => {
+		const fetchUsageEntries = vi.fn().mockResolvedValue(null);
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries });
+
+		refresher.refresh(access, ["day"], { setStatus, accent: (text) => text });
+
+		await vi.waitFor(() => expect(fetchUsageEntries).toHaveBeenCalledOnce());
+		expect(setStatus).not.toHaveBeenCalled();
+	});
+
 	test("coalesces active refreshes and applies only the most recent result", async () => {
-		vi.stubEnv("KILO_USAGE", "1");
 		const first = deferred<KiloUsageEntry[] | null>();
 		const second = deferred<KiloUsageEntry[] | null>();
 		const fetchUsageEntries = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
@@ -78,9 +97,9 @@ describe("createUsageRefresher", () => {
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
 		const presentation = { setStatus, accent: (text: string) => text };
 
-		refresher.refresh(access, presentation);
-		refresher.refresh({ token: "newest-token" }, presentation);
-		refresher.refresh({ token: "newest-token" }, presentation);
+		refresher.refresh(access, ["day"], presentation);
+		refresher.refresh({ token: "newest-token" }, ["day"], presentation);
+		refresher.refresh({ token: "newest-token" }, ["day"], presentation);
 
 		expect(fetchUsageEntries).toHaveBeenCalledTimes(1);
 		first.resolve([{ date: "2026-08-22", totalCostMicrodollars: 1_000_000 }]);


### PR DESCRIPTION
Load non-secret footer, credit, and usage preferences from global and trusted project configuration files. Environment variables remain the highest-precedence override.