### PR TITLE
Fix/type safe config validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@kilocode/kilo-pi-provider",
       "version": "2026.08.1",
       "license": "BSL-1.0",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
       "devDependencies": {
         "@biomejs/biome": "2.3.5",
         "@earendil-works/pi-ai": "0.84.4",
@@ -3496,7 +3499,6 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
       "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "@vitest/coverage-v8": "4.1.9",
     "typescript": "5.9.3",
     "vitest": "4.1.9"
+  },
+  "dependencies": {
+    "typebox": "1.3.7"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,8 @@ const CreditsPreferences = Type.Object({ enabled: Type.Optional(Type.Boolean()) 
 const UsagePreferences = Type.Object({
 	periods: Type.Optional(Type.Array(Type.Enum(KILO_USAGE_PERIODS))),
 });
-const PreferencesContainer = Type.Object({});
+// Validate sections separately so one malformed section does not discard valid siblings.
+const PreferencesRoot = Type.Object({});
 
 export type KiloPreferences = {
 	footer?: Type.Static<typeof FooterPreferences>;
@@ -41,7 +42,7 @@ function readKiloPreferences(path: string): KiloPreferences {
 	if (!existsSync(path)) return {};
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-		if (!Value.Check(PreferencesContainer, parsed)) return {};
+		if (!Value.Check(PreferencesRoot, parsed)) return {};
 
 		const footer = "footer" in parsed && Value.Check(FooterPreferences, parsed.footer) ? parsed.footer : undefined;
 		const credits =

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,23 @@
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import Type from "typebox";
+import Value from "typebox/value";
 
 export const KILO_USAGE_PERIODS = ["day", "week", "month", "year"] as const;
 export type KiloUsageDisplayPeriod = (typeof KILO_USAGE_PERIODS)[number];
 
+const FooterPreferences = Type.Object({ custom: Type.Optional(Type.Boolean()) });
+const CreditsPreferences = Type.Object({ enabled: Type.Optional(Type.Boolean()) });
+const UsagePreferences = Type.Object({
+	periods: Type.Optional(Type.Array(Type.Enum(KILO_USAGE_PERIODS))),
+});
+const PreferencesContainer = Type.Object({});
+
 export type KiloPreferences = {
-	footer?: { custom?: boolean };
-	credits?: { enabled?: boolean };
-	usage?: { periods?: KiloUsageDisplayPeriod[] };
+	footer?: Type.Static<typeof FooterPreferences>;
+	credits?: Type.Static<typeof CreditsPreferences>;
+	usage?: Type.Static<typeof UsagePreferences>;
 };
 
 export type ResolvedKiloPreferences = {
@@ -24,35 +33,25 @@ const DEFAULT_PREFERENCES: ResolvedKiloPreferences = {
 	usage: { periods: [] },
 };
 
-function isUsagePeriod(value: unknown): value is KiloUsageDisplayPeriod {
-	return typeof value === "string" && KILO_USAGE_PERIODS.includes(value as KiloUsageDisplayPeriod);
-}
-
-type PreferencesObject = {
-	footer?: unknown;
-	credits?: unknown;
-	usage?: unknown;
-};
-
-function isPreferencesObject(value: unknown): value is PreferencesObject {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
+function isUsagePeriod(value: string): value is KiloUsageDisplayPeriod {
+	return KILO_USAGE_PERIODS.some((period) => period === value);
 }
 
 function readKiloPreferences(path: string): KiloPreferences {
 	if (!existsSync(path)) return {};
 	try {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-		if (!isPreferencesObject(parsed)) return {};
-		const footer = isPreferencesObject(parsed.footer) ? parsed.footer : undefined;
-		const credits = isPreferencesObject(parsed.credits) ? parsed.credits : undefined;
-		const usage = isPreferencesObject(parsed.usage) ? parsed.usage : undefined;
+		if (!Value.Check(PreferencesContainer, parsed)) return {};
+
+		const footer = "footer" in parsed && Value.Check(FooterPreferences, parsed.footer) ? parsed.footer : undefined;
+		const credits =
+			"credits" in parsed && Value.Check(CreditsPreferences, parsed.credits) ? parsed.credits : undefined;
+		const usage = "usage" in parsed && Value.Check(UsagePreferences, parsed.usage) ? parsed.usage : undefined;
+
 		return {
-			footer: typeof footer?.custom === "boolean" ? { custom: footer.custom } : undefined,
-			credits: typeof credits?.enabled === "boolean" ? { enabled: credits.enabled } : undefined,
-			usage:
-				Array.isArray(usage?.periods) && usage.periods.every(isUsagePeriod)
-					? { periods: usage.periods }
-					: undefined,
+			footer: footer?.custom === undefined ? undefined : { custom: footer.custom },
+			credits: credits?.enabled === undefined ? undefined : { enabled: credits.enabled },
+			usage: usage?.periods === undefined ? undefined : { periods: usage.periods },
 		};
 	} catch {
 		return {};

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -90,6 +90,51 @@ describe("loadKiloPreferences", () => {
 		});
 	});
 
+	test("keeps valid sections when a sibling section is invalid", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, {
+			footer: { custom: false },
+			credits: { enabled: "yes" },
+			usage: { periods: ["day", "invalid"] },
+		});
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			footer: { custom: false },
+			credits: { enabled: true },
+			usage: { periods: [] },
+		});
+	});
+
+	test("ignores unknown properties in valid sections", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, {
+			footer: { custom: false, unknown: 123 },
+			credits: { enabled: false, unknown: 123 },
+			usage: { periods: [], unknown: 123 },
+			unknown: 123,
+		});
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			footer: { custom: false },
+			credits: { enabled: false },
+			usage: { periods: [] },
+		});
+	});
+
+	test("ignores sections whose known property is absent", () => {
+		const agentDirectory = createDirectory();
+		const cwd = createDirectory();
+		writeConfig(agentDirectory, { footer: {}, credits: {}, usage: {} });
+
+		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			footer: { custom: true },
+			credits: { enabled: true },
+			usage: { periods: [] },
+		});
+	});
+
 	test.each(["{", "null", "[]"])("falls back to defaults for invalid config: %s", (config) => {
 		const agentDirectory = createDirectory();
 		const cwd = createDirectory();


### PR DESCRIPTION
## Summary

Fix configuration parsing so runtime validation and TypeScript types describe the same facts.

## Problem

The previous `isPreferencesObject` guard only checked whether a value was a non-array object, but claimed it had the top-level preferences structure. It was then reused for nested footer, credits, and usage sections.

As a result, TypeScript correctly rejected accesses such as `footer.custom`: the guard narrowed nested sections to the wrong shape. Expanding that shape or casting parsed JSON would only hide the mismatch without validating the data.

## Fix

- Keep parsed JSON as unknown.
- Define TypeBox schemas for each preference section.
- Validate the root as an object, then validate each section independently with Value.Check.
- Derive section types from the same schemas used at runtime.
- Preserve valid sections when a sibling section is malformed.
- Ignore unknown properties while rejecting invalid known property values.
- Add focused tests for malformed siblings, unknown properties, and empty sections.

`TypeBox` is also the runtime schema system used throughout Pi for protocol validation, tool parameters, and configuration. Using it here follows the project’s established validation pattern. It is declared as a direct runtime dependency rather than relying on Pi’s transitive installation.

The remaining typecheck errors belong to separate OAuth, usage-test, and Vitest configuration follow-ups.
