### PR TITLE
Fix overlapping Kilo usage period aggregation.

### DIFF
--- a/src/usage.ts
+++ b/src/usage.ts
@@ -29,14 +29,37 @@ export function getUsageFetchPeriod(periods: KiloUsageDisplayPeriod[]): KiloUsag
 }
 
 export function sumUsageForDay(entries: KiloUsageEntry[], date: Date): number {
-	const today = date.toISOString().slice(0, 10);
-	return entries
-		.filter((entry) => entry.date === today)
-		.reduce((total, entry) => total + entry.totalCostMicrodollars, 0);
+	return sumUsageForPeriod(entries, "day", date);
 }
 
-function sumUsage(entries: KiloUsageEntry[]): number {
-	return entries.reduce((total, entry) => total + entry.totalCostMicrodollars, 0);
+function startOfUtcDay(date: Date): Date {
+	return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function nextPeriodBoundary(period: KiloUsageDisplayPeriod, now: Date): [string, string] {
+	const start = startOfUtcDay(now);
+	if (period === "week") {
+		const daysSinceMonday = (start.getUTCDay() + 6) % 7;
+		start.setUTCDate(start.getUTCDate() - daysSinceMonday);
+	} else if (period === "month") {
+		start.setUTCDate(1);
+	} else if (period === "year") {
+		start.setUTCMonth(0, 1);
+	}
+
+	const end = new Date(start);
+	if (period === "day") end.setUTCDate(end.getUTCDate() + 1);
+	if (period === "week") end.setUTCDate(end.getUTCDate() + 7);
+	if (period === "month") end.setUTCMonth(end.getUTCMonth() + 1);
+	if (period === "year") end.setUTCFullYear(end.getUTCFullYear() + 1);
+	return [start.toISOString().slice(0, 10), end.toISOString().slice(0, 10)];
+}
+
+export function sumUsageForPeriod(entries: KiloUsageEntry[], period: KiloUsageDisplayPeriod, now: Date): number {
+	const [start, end] = nextPeriodBoundary(period, now);
+	return entries
+		.filter((entry) => entry.date >= start && entry.date < end)
+		.reduce((total, entry) => total + entry.totalCostMicrodollars, 0);
 }
 
 function formatUsage(microdollars: number, period: KiloUsageDisplayPeriod): string {
@@ -61,7 +84,7 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 			if (!entries || request.revision !== revision) return;
 
 			for (const period of request.periods) {
-				const spend = period === "day" ? sumUsageForDay(entries, now()) : sumUsage(entries);
+				const spend = sumUsageForPeriod(entries, period, now());
 				request.presentation.setStatus(
 					getUsageStatusKey(period),
 					request.presentation.accent(formatUsage(spend, period)),

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
 import type { KiloAccess, KiloUsageEntry } from "../src/api.ts";
-import { createUsageRefresher, getUsageFetchPeriod, sumUsageForDay } from "../src/usage.ts";
+import {
+	createUsageRefresher,
+	getUsageFetchPeriod,
+	type KiloUsageDisplayPeriod,
+	sumUsageForDay,
+} from "../src/usage.ts";
 
 const access: KiloAccess = { token: "access-token" };
 const today = new Date("2026-08-22T12:00:00.000Z");
@@ -18,9 +23,12 @@ describe("getUsageFetchPeriod", () => {
 		[["day"], "week"],
 		[["month"], "month"],
 		[["year"], "year"],
-	])("uses %s for %s usage", (periods, fetchPeriod) => {
-		expect(getUsageFetchPeriod(periods)).toBe(fetchPeriod);
-	});
+	] satisfies Array<[KiloUsageDisplayPeriod[], "week" | "month" | "year"]>)(
+		"uses %s for %s usage",
+		(periods, fetchPeriod) => {
+			expect(getUsageFetchPeriod(periods)).toBe(fetchPeriod);
+		},
+	);
 });
 
 describe("sumUsageForDay", () => {
@@ -67,6 +75,25 @@ describe("createUsageRefresher", () => {
 			expect(setStatus).toHaveBeenCalledWith(`kilo-usage-${period}`, expectedStatus);
 		});
 		expect(fetchUsageEntries).toHaveBeenCalledWith(access, fetchPeriod);
+	});
+
+	test("derives mixed periods from one widest-range request", async () => {
+		const fetchUsageEntries = vi.fn().mockResolvedValue([
+			{ date: "2026-08-03", totalCostMicrodollars: 9_000_000 },
+			{ date: "2026-08-15", totalCostMicrodollars: 5_000_000 },
+			{ date: "2026-08-21", totalCostMicrodollars: 2_000_000 },
+			{ date: "2026-08-22", totalCostMicrodollars: 1_000_000 },
+		]);
+		const setStatus = vi.fn();
+		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
+
+		refresher.refresh(access, ["week", "month"], { setStatus, accent: (text) => text });
+
+		await vi.waitFor(() => {
+			expect(setStatus).toHaveBeenCalledWith("kilo-usage-week", "💸 $3.00 this week");
+			expect(setStatus).toHaveBeenCalledWith("kilo-usage-month", "💸 $17.00 this month");
+		});
+		expect(fetchUsageEntries).toHaveBeenCalledWith(access, "month");
 	});
 
 	test("does not fetch usage for an empty period list", () => {


### PR DESCRIPTION
Derive each selected period from the shared widest-range response using its own UTC boundary. A calendar week can cross a month boundary, so a month response cannot always calculate the full selected week without an additional request.