### PR TITLE
feat: namespace Pi extension environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+## [2026.08.2] - 2026-08-30
+
+### Breaking Changes
+
+- Rename Pi-extension environment variables to the `KILO_PI_` namespace ([#26](https://github.com/Kilo-Org/kilo-pi-provider/pull/26)):
+  - `KILO_CUSTOM_FOOTER` → `KILO_PI_CUSTOM_FOOTER`
+  - `KILO_SHOW_CREDITS` → `KILO_PI_SHOW_CREDITS`
+  - `KILO_USAGE` → `KILO_PI_USAGE`
+
+### Fixed
+
+- Derive each selected usage period from the shared widest-range API response ([#25](https://github.com/Kilo-Org/kilo-pi-provider/pull/25)).
+
 ## [2026.08.1] - 2026-08-29
 
 ### Added
@@ -15,7 +28,7 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ### Changed
 
-- Support comma-separated usage periods in configuration and `KILO_USAGE`, for example `day,week` ([#21](https://github.com/Kilo-Org/kilo-pi-provider/pull/21)).
+- Support comma-separated usage periods in configuration and `KILO_PI_USAGE`, for example `day,week` ([#21](https://github.com/Kilo-Org/kilo-pi-provider/pull/21)).
 
 ## [2026.08.0] - 2026-08-29
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ You can also set `KILO_API_KEY` directly instead of using the login flow. Set `K
 Kilo replaces Pi's footer by default to show usage and credits. To keep another extension's custom footer, disable Kilo's footer:
 
 ```bash
-KILO_CUSTOM_FOOTER=0 pi
+KILO_PI_CUSTOM_FOOTER=0 pi
 ```
 
-Kilo credits are shown by default and remain available as the `kilo-credits` footer status. To hide them and avoid balance requests, set `KILO_SHOW_CREDITS=0`:
+Kilo credits are shown by default and remain available as the `kilo-credits` footer status. To hide them and avoid balance requests, set `KILO_PI_SHOW_CREDITS=0`:
 
 ```bash
-KILO_SHOW_CREDITS=0 pi
+KILO_PI_SHOW_CREDITS=0 pi
 ```
 
 ### Preferences
@@ -80,10 +80,10 @@ A trusted project file overrides the global file, and environment variables over
 Environment overrides are useful for one-off sessions:
 
 ```bash
-KILO_USAGE=day,week pi
+KILO_PI_USAGE=day,week pi
 ```
 
-`KILO_USAGE` accepts comma-separated periods; `1`, `true`, and `yes` remain shorthand for `day`. Usage refreshes at session start and after completed turns.
+`KILO_PI_USAGE` accepts comma-separated periods; `1`, `true`, and `yes` remain shorthand for `day`. Usage refreshes at session start and after completed turns.
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.1",
+  "version": "2026.08.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilocode/kilo-pi-provider",
-      "version": "2026.08.1",
+      "version": "2026.08.2",
       "license": "BSL-1.0",
       "dependencies": {
         "typebox": "1.3.7"
@@ -1333,9 +1333,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1353,9 +1350,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1373,9 +1367,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1393,9 +1384,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,9 +1401,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.1",
+  "version": "2026.08.2",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,9 +87,9 @@ function environmentUsagePeriods(value: string | undefined): KiloUsageDisplayPer
 
 export function getEnvironmentPreferences(environment: NodeJS.ProcessEnv = process.env): KiloPreferences {
 	return {
-		footer: { custom: environmentBoolean(environment.KILO_CUSTOM_FOOTER, true) },
-		credits: { enabled: environmentBoolean(environment.KILO_SHOW_CREDITS, true) },
-		usage: { periods: environmentUsagePeriods(environment.KILO_USAGE) },
+		footer: { custom: environmentBoolean(environment.KILO_PI_CUSTOM_FOOTER, true) },
+		credits: { enabled: environmentBoolean(environment.KILO_PI_SHOW_CREDITS, true) },
+		usage: { periods: environmentUsagePeriods(environment.KILO_PI_USAGE) },
 	};
 }
 

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -12,7 +12,7 @@ export type FooterContext = {
 export type FooterExtensionAPI = Pick<ExtensionAPI, "getThinkingLevel">;
 
 export function usesCustomFooter(): boolean {
-	const value = process.env.KILO_CUSTOM_FOOTER?.trim().toLowerCase();
+	const value = process.env.KILO_PI_CUSTOM_FOOTER?.trim().toLowerCase();
 	return !["0", "false", "no"].includes(value ?? "");
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -22,15 +22,17 @@ test("merges global, project, and environment preferences in precedence order", 
 });
 
 test.each([
-	["KILO_USAGE=day,week", { KILO_USAGE: "day,week" }, ["day", "week"]],
-	["legacy truthy KILO_USAGE", { KILO_USAGE: "true" }, ["day"]],
-	["disabled KILO_USAGE", { KILO_USAGE: "0" }, []],
+	["KILO_PI_USAGE=day,week", { KILO_PI_USAGE: "day,week" }, ["day", "week"]],
+	["legacy truthy KILO_PI_USAGE", { KILO_PI_USAGE: "true" }, ["day"]],
+	["disabled KILO_PI_USAGE", { KILO_PI_USAGE: "0" }, []],
 ])("parses %s", (_name, environment, periods) => {
 	expect(getEnvironmentPreferences(environment).usage?.periods).toEqual(periods);
 });
 
 test("uses defaults for unrecognized boolean environment values", () => {
-	expect(getEnvironmentPreferences({ KILO_CUSTOM_FOOTER: "maybe", KILO_SHOW_CREDITS: "unexpected" })).toMatchObject({
+	expect(
+		getEnvironmentPreferences({ KILO_PI_CUSTOM_FOOTER: "maybe", KILO_PI_SHOW_CREDITS: "unexpected" }),
+	).toMatchObject({
 		footer: { custom: true },
 		credits: { enabled: true },
 	});
@@ -73,7 +75,7 @@ describe("loadKiloPreferences", () => {
 				agentDirectory,
 				cwd,
 				projectTrusted: false,
-				environment: { KILO_SHOW_CREDITS: "true", KILO_CUSTOM_FOOTER: "0", KILO_USAGE: "day,week" },
+				environment: { KILO_PI_SHOW_CREDITS: "true", KILO_PI_CUSTOM_FOOTER: "0", KILO_PI_USAGE: "day,week" },
 			}),
 		).toEqual({ footer: { custom: false }, credits: { enabled: true }, usage: { periods: ["day", "week"] } });
 	});

--- a/test/footer.test.ts
+++ b/test/footer.test.ts
@@ -15,8 +15,8 @@ test.each([
 	["false", false],
 	["FALSE", false],
 	[" no ", false],
-])("usesCustomFooter returns %s for KILO_CUSTOM_FOOTER=%s", (value, expected) => {
-	vi.stubEnv("KILO_CUSTOM_FOOTER", value);
+])("usesCustomFooter returns %s for KILO_PI_CUSTOM_FOOTER=%s", (value, expected) => {
+	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", value);
 	expect(usesCustomFooter()).toBe(expected);
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -15,9 +15,9 @@ beforeEach(() => {
 	vi.stubEnv("KILO_API_KEY", "");
 	vi.stubEnv("KILO_ORG_ID", "");
 	vi.stubEnv("KILOCODE_ORGANIZATION_ID", "");
-	vi.stubEnv("KILO_CUSTOM_FOOTER", "0");
-	vi.stubEnv("KILO_SHOW_CREDITS", "");
-	vi.stubEnv("KILO_USAGE", "");
+	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "0");
+	vi.stubEnv("KILO_PI_SHOW_CREDITS", "");
+	vi.stubEnv("KILO_PI_USAGE", "");
 });
 
 afterEach(() => {
@@ -68,7 +68,7 @@ test("parsePrice returns zero for an invalid price", () => {
 });
 
 async function customFooterWasInstalled(customFooter: string): Promise<boolean> {
-	vi.stubEnv("KILO_CUSTOM_FOOTER", customFooter);
+	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", customFooter);
 	vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(catalogResponse()));
 
 	const on = vi.fn();
@@ -125,7 +125,7 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 	expect(context.ui.setFooter).not.toHaveBeenCalled();
 });
 
-test("does not fetch or display credits when KILO_SHOW_CREDITS is disabled", async () => {
+test("does not fetch or display credits when KILO_PI_SHOW_CREDITS is disabled", async () => {
 	const runtime = createRuntime({ apiKey: "api-key" });
 	const configDirectory = join(agentDirectory, "extensions", "kilo-pi-provider");
 	mkdirSync(configDirectory, { recursive: true });
@@ -377,7 +377,7 @@ test("does not request usage or set a usage status by default", async () => {
 });
 
 test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes", async (value) => {
-	vi.stubEnv("KILO_USAGE", value);
+	vi.stubEnv("KILO_PI_USAGE", value);
 	const runtime = createRuntime({
 		apiKey: "api-key",
 		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 1_234_567 }] },
@@ -393,7 +393,7 @@ test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes"
 });
 
 test("turn_end schedules an enabled daily usage refresh", async () => {
-	vi.stubEnv("KILO_USAGE", "day");
+	vi.stubEnv("KILO_PI_USAGE", "day");
 	const runtime = createRuntime({
 		apiKey: "api-key",
 		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 2_000_000 }] },
@@ -408,7 +408,7 @@ test("turn_end schedules an enabled daily usage refresh", async () => {
 });
 
 test("turn_end does not wait for an enabled usage response", async () => {
-	vi.stubEnv("KILO_USAGE", "day");
+	vi.stubEnv("KILO_PI_USAGE", "day");
 	const usageResponse = deferred<Response>();
 	const runtime = createRuntime({ apiKey: "api-key", usageResponse: usageResponse.promise });
 

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -7,7 +7,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJson = JSON.parse(readFileSync(resolve(repositoryRoot, "package.json"), "utf8"));
 
 test("declares the first calendar-versioned release", () => {
-	expect(packageJson.version).toBe("2026.08.1");
+	expect(packageJson.version).toBe("2026.08.2");
 });
 
 test("declared Pi extension entry points exist", () => {


### PR DESCRIPTION
Rename footer, credits, and usage settings to the KILO_PI_ namespace to distinguish them from shared Kilo connection variables. This is an intentional breaking change.