### PR TITLE
fix: classify malformed Responses stream errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+### Fixed
+
+- Classify malformed Kilo Responses failures that provide `error.type` without the required `error.code`.
+
 ## [2026.08.2] - 2026-08-30
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "@vitest/coverage-v8": "4.1.9",
         "typescript": "5.9.3",
         "vitest": "4.1.9"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "*"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "dependencies": {
     "typebox": "1.3.7"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./auth.ts";
 import { loadKiloPreferences } from "./config.ts";
 import { installCustomFooter } from "./footer.ts";
+import { streamKiloResponses } from "./responses.ts";
 
 import { createUsageRefresher } from "./usage.ts";
 
@@ -105,7 +106,10 @@ async function fetchKiloModels(options?: {
 const KILO_PROVIDER_CONFIG = {
 	baseUrl: KILO_GATEWAY_BASE,
 	apiKey: "$KILO_API_KEY",
-	api: "openai-completions" as const,
+	// Pi applies a custom streamSimple only to models whose API matches this one.
+	// mapOpenRouterModel assigns both Responses and chat-completions APIs explicitly.
+	api: "openai-responses" as const,
+	streamSimple: streamKiloResponses,
 	headers: {
 		"X-KILOCODE-EDITORNAME": "Pi",
 		"User-Agent": "pi-kilo-provider",

--- a/src/models.ts
+++ b/src/models.ts
@@ -176,12 +176,13 @@ export function mapOpenRouterModel(m: OpenRouterModel): ProviderModelConfig {
 	const supportsReasoning = m.supported_parameters?.includes("reasoning") ?? false;
 	const maxTokens =
 		m.top_provider?.max_completion_tokens ?? m.max_completion_tokens ?? Math.ceil(m.context_length * 0.2);
-	const api = shouldUseResponsesApi(m) ? ("openai-responses" as const) : undefined;
+	const api = shouldUseResponsesApi(m) ? ("openai-responses" as const) : ("openai-completions" as const);
 
 	return {
 		id: m.id,
 		name: m.name,
-		...(api ? { api, baseUrl: KILO_OPENROUTER_BASE } : {}),
+		api,
+		...(api === "openai-responses" ? { baseUrl: KILO_OPENROUTER_BASE } : {}),
 		reasoning: supportsReasoning,
 		input: supportsImages ? ["text", "image"] : ["text"],
 		cost: {

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,0 +1,127 @@
+import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { openAIResponsesApi } from "@earendil-works/pi-ai/compat";
+
+const openAIResponses = openAIResponsesApi();
+
+type JsonObject = Record<string, unknown>;
+
+function isJsonObject(value: unknown): value is JsonObject {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Kilo may receive a non-standard Responses error from an upstream gateway
+ * with `error.type` but no required `error.code`. Preserve the failure while
+ * supplying the field expected by the OpenAI Responses parser.
+ */
+export function normalizeResponseFailedEvent(event: unknown): unknown {
+	if (!isJsonObject(event) || event.type !== "response.failed") return event;
+
+	const response = event.response;
+	if (!isJsonObject(response)) return event;
+
+	const error = response.error;
+	if (!isJsonObject(error) || (error.code !== undefined && error.code !== null)) return event;
+	if (typeof error.type !== "string" || error.type.length === 0) return event;
+
+	return {
+		...event,
+		response: {
+			...response,
+			error: {
+				...error,
+				code: error.type,
+			},
+		},
+	};
+}
+
+function sseData(line: string): string | undefined {
+	if (!line.startsWith("data:")) return undefined;
+	const value = line.slice("data:".length);
+	return value.startsWith(" ") ? value.slice(1) : value;
+}
+
+export function normalizeSseEvent(eventText: string): string {
+	if (!eventText.includes("response.failed")) return eventText;
+
+	const lines = eventText.split(/\r\n|\r|\n/u);
+	const payload = lines.flatMap((line) => {
+		const data = sseData(line);
+		return data === undefined ? [] : [data];
+	});
+	if (payload.length === 0) return eventText;
+
+	try {
+		const event = JSON.parse(payload.join("\n")) as unknown;
+		const normalized = normalizeResponseFailedEvent(event);
+		if (normalized === event) return eventText;
+
+		let wroteData = false;
+		return lines
+			.flatMap((line) => {
+				if (sseData(line) === undefined) return [line];
+				if (wroteData) return [];
+				wroteData = true;
+				return [`data: ${JSON.stringify(normalized)}`];
+			})
+			.join("\n");
+	} catch {
+		return eventText;
+	}
+}
+
+function normalizeSseBody(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	// Keep CRLF atomic so regex backtracking cannot mistake one line ending for a blank line.
+	const eventSeparator = /(?:\r\n|\r(?!\n)|(?<!\r)\n)(?:\r\n|\r(?!\n)|(?<!\r)\n)/u;
+	let buffered = "";
+
+	function emitEvents(controller: TransformStreamDefaultController<Uint8Array>): void {
+		for (;;) {
+			const separator = eventSeparator.exec(buffered);
+			if (!separator) return;
+
+			const eventText = buffered.slice(0, separator.index);
+			controller.enqueue(encoder.encode(`${normalizeSseEvent(eventText)}${separator[0]}`));
+			buffered = buffered.slice(separator.index + separator[0].length);
+		}
+	}
+
+	return body.pipeThrough(
+		new TransformStream<Uint8Array, Uint8Array>({
+			transform(chunk, controller) {
+				buffered += decoder.decode(chunk, { stream: true });
+				emitEvents(controller);
+			},
+			flush(controller) {
+				buffered += decoder.decode();
+				emitEvents(controller);
+				if (buffered.length > 0) controller.enqueue(encoder.encode(buffered));
+			},
+		}),
+	);
+}
+
+export function normalizeResponsesFetch(fetchImplementation: typeof fetch): typeof fetch {
+	return async (input, init) => {
+		const response = await fetchImplementation(input, init);
+		if (!response.body || !response.headers.get("content-type")?.toLowerCase().includes("text/event-stream")) {
+			return response;
+		}
+
+		return new Response(normalizeSseBody(response.body), {
+			status: response.status,
+			statusText: response.statusText,
+			headers: response.headers,
+		});
+	};
+}
+
+export function streamKiloResponses(model: Model<Api>, context: Context, options?: SimpleStreamOptions) {
+	return openAIResponses.streamSimple(model, context, {
+		...options,
+		fetch: normalizeResponsesFetch(options?.fetch ?? globalThis.fetch),
+	});
+}

--- a/test/fixtures/malformed-response-failed.sse
+++ b/test/fixtures/malformed-response-failed.sse
@@ -1,0 +1,16 @@
+event: response.created
+data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_test","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","sequence_number":1,"output_index":0,"item":{"type":"message","id":"msg_test","status":"in_progress","role":"assistant","content":[],"phase":"final_answer"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_test","output_index":0,"content_index":0,"delta":"OK","logprobs":[]}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"type":"message","id":"msg_test","status":"completed","role":"assistant","content":[{"type":"output_text","text":"OK","annotations":[],"logprobs":[]}],"phase":"final_answer"}}
+
+event: response.failed
+data: {"type":"response.failed","sequence_number":4,"response":{"id":"resp_test","status":"failed","error":{"type":"server_error","message":"An error occurred"},"output":[]}}
+
+: stream closed

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -156,10 +156,13 @@ test("registers anonymous free models from the Kilo catalog", async () => {
 		expect.objectContaining({
 			baseUrl: "https://api.kilo.ai/api/gateway",
 			apiKey: "$KILO_API_KEY",
+			api: "openai-responses",
+			streamSimple: expect.any(Function),
 			models: [
 				expect.objectContaining({
 					id: "acme/code-model:free",
 					name: "Acme Code Model",
+					api: "openai-completions",
 					reasoning: true,
 					input: ["text"],
 					contextWindow: 128_000,

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -16,6 +16,19 @@ const modelWithGatewayVariants: OpenRouterModel = {
 };
 
 describe("mapOpenRouterModel", () => {
+	test("routes OpenAI models to Responses and other models to chat completions", () => {
+		const completionsModel = mapOpenRouterModel(modelWithGatewayVariants);
+		const responsesModel = mapOpenRouterModel({
+			...modelWithGatewayVariants,
+			opencode: { ...modelWithGatewayVariants.opencode, ai_sdk_provider: "openai" },
+		});
+
+		expect(completionsModel.api).toBe("openai-completions");
+		expect(completionsModel.baseUrl).toBeUndefined();
+		expect(responsesModel.api).toBe("openai-responses");
+		expect(responsesModel.baseUrl).toBe("https://api.kilo.ai/api/openrouter");
+	});
+
 	test("maps gateway thinking variants", () => {
 		expect(mapOpenRouterModel(modelWithGatewayVariants).thinkingLevelMap).toEqual({
 			off: "none",

--- a/test/responses.test.ts
+++ b/test/responses.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+import { isRetryableAssistantError, type Model } from "@earendil-works/pi-ai";
+import { afterEach, expect, test, vi } from "vitest";
+import {
+	normalizeResponseFailedEvent,
+	normalizeResponsesFetch,
+	normalizeSseEvent,
+	streamKiloResponses,
+} from "../src/responses.ts";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+const model: Model<"openai-responses"> = {
+	id: "gpt-test",
+	name: "Responses Test Model",
+	api: "openai-responses",
+	provider: "kilo",
+	baseUrl: "https://api.kilo.ai/api/openrouter",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 16_000,
+};
+
+test("classifies malformed Responses failures by their error type", async () => {
+	const fixture = readFileSync(new URL("./fixtures/malformed-response-failed.sse", import.meta.url), "utf8");
+	const responseFetch = vi.fn<typeof fetch>().mockResolvedValue(
+		new Response(fixture, {
+			status: 200,
+			headers: { "Content-Type": "text/event-stream" },
+		}),
+	);
+	const stream = streamKiloResponses(
+		model,
+		{ messages: [{ role: "user", content: "Reply with OK", timestamp: 0 }] },
+		{ apiKey: "test-key", fetch: responseFetch, maxRetries: 0 },
+	);
+	const events = [];
+	for await (const event of stream) events.push(event);
+	const result = await stream.result();
+
+	expect(responseFetch).toHaveBeenCalledOnce();
+	expect(events.at(-1)?.type).toBe("error");
+	expect(result).toMatchObject({
+		content: [{ type: "text", text: "OK" }],
+		stopReason: "error",
+		rawStopReason: "failed",
+		errorMessage: "server_error: An error occurred",
+	});
+	expect(isRetryableAssistantError(result)).toBe(true);
+});
+
+test("normalizes multiline failure events across transport chunks", async () => {
+	const chunks = [
+		"event: response.failed\r",
+		'\ndata: {"type":"response.failed",\r\n',
+		'data: "sequence_number":0,\r\n',
+		'data: "response":{"status":"failed","error":{"type":"server_error","message":"An error occurred"}}}\r\n',
+		"\r\n: stream closed\r\n",
+	];
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			const encoder = new TextEncoder();
+			for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+			controller.close();
+		},
+	});
+	const responseFetch = vi.fn<typeof fetch>().mockResolvedValue(
+		new Response(body, {
+			status: 200,
+			headers: { "Content-Type": "text/event-stream" },
+		}),
+	);
+
+	const result = await streamKiloResponses(
+		model,
+		{ messages: [] },
+		{ apiKey: "test-key", fetch: responseFetch },
+	).result();
+
+	expect(result).toMatchObject({
+		stopReason: "error",
+		rawStopReason: "failed",
+		errorMessage: "server_error: An error occurred",
+	});
+});
+
+test("does not overwrite a standard Responses error code", () => {
+	const event = {
+		type: "response.failed",
+		response: {
+			error: {
+				type: "server_error",
+				code: "rate_limit_exceeded",
+				message: "Slow down",
+			},
+		},
+	};
+
+	expect(normalizeResponseFailedEvent(event)).toBe(event);
+});
+
+test("treats a null Responses error code as absent", () => {
+	const event = {
+		type: "response.failed",
+		response: { error: { type: "server_error", code: null, message: "Try again" } },
+	};
+
+	expect(normalizeResponseFailedEvent(event)).toMatchObject({
+		response: { error: { type: "server_error", code: "server_error", message: "Try again" } },
+	});
+});
+
+test.each([
+	["a primitive", null],
+	["an array", []],
+	["another event", { type: "response.completed" }],
+	["a missing response", { type: "response.failed" }],
+	["an invalid response", { type: "response.failed", response: null }],
+	["a missing error", { type: "response.failed", response: {} }],
+	["an invalid error", { type: "response.failed", response: { error: [] } }],
+	["a missing error type", { type: "response.failed", response: { error: { message: "No type" } } }],
+	["an empty error type", { type: "response.failed", response: { error: { type: "", message: "Empty type" } } }],
+])("leaves %s unchanged", (_name, event) => {
+	expect(normalizeResponseFailedEvent(event)).toBe(event);
+});
+
+test.each([
+	["an unrelated event", 'event: response.completed\ndata: {"type":"response.completed"}'],
+	["a failure event without data", "event: response.failed"],
+	["a failure event with invalid JSON", "event: response.failed\ndata: response.failed{"],
+	[
+		"a standard failure event",
+		'event: response.failed\ndata: {"type":"response.failed","response":{"error":{"type":"server_error","code":"server_error","message":"Try again"}}}',
+	],
+])("preserves %s byte-for-byte", (_name, eventText) => {
+	expect(normalizeSseEvent(eventText)).toBe(eventText);
+});
+
+test("normalizes an SSE data field without a space after its colon", () => {
+	const eventText =
+		'event: response.failed\ndata:{"type":"response.failed","response":{"status":"failed","error":{"type":"server_error","message":"Try again"}}}';
+
+	expect(normalizeSseEvent(eventText)).toContain(
+		'data: {"type":"response.failed","response":{"status":"failed","error":{"type":"server_error","message":"Try again","code":"server_error"}}}',
+	);
+});
+
+test.each([
+	["a bodyless response", new Response(null, { status: 204 })],
+	["a response without a content type", new Response("plain text")],
+	["a non-SSE response", new Response("{}", { headers: { "Content-Type": "application/json" } })],
+])("does not wrap %s", async (_name, response) => {
+	const fetchImplementation = vi.fn<typeof fetch>().mockResolvedValue(response);
+
+	await expect(normalizeResponsesFetch(fetchImplementation)("https://example.test")).resolves.toBe(response);
+});
+
+test("uses the global fetch implementation when none is supplied", async () => {
+	const failure =
+		'event: response.failed\ndata: {"type":"response.failed","response":{"status":"failed","error":{"type":"server_error","message":"Try again"}}}\n\n';
+	const fetchImplementation = vi
+		.fn<typeof fetch>()
+		.mockResolvedValue(new Response(failure, { headers: { "Content-Type": "text/event-stream" } }));
+	vi.stubGlobal("fetch", fetchImplementation);
+
+	const result = await streamKiloResponses(model, { messages: [] }, { apiKey: "test-key" }).result();
+
+	expect(fetchImplementation).toHaveBeenCalledOnce();
+	expect(result).toMatchObject({ stopReason: "error", errorMessage: "server_error: Try again" });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
 			exclude: ["src/**/*.d.ts"],
 			reporter: ["text", "html", "lcov"],
 			reportsDirectory: "coverage",
+			thresholds: {
+				"src/responses.ts": { 100: true },
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary

- wrap Kilo Responses SSE streams at the provider boundary
- copy `response.error.type` to the required `response.error.code` when a failed response omits the code
- leave valid Responses errors and Chat Completions traffic unchanged
- preserve `response.failed` as a failed turn, including when output was already emitted

## Why

Some gateway-routed Responses streams emit completed output and then terminate with a malformed event like:

```json
{
  "type": "response.failed",
  "response": {
    "status": "failed",
    "error": {
      "type": "server_error",
      "message": "An error occurred"
    }
  }
}
```

The OpenAI Responses schema requires `error.code`. Without it, Pi reports `unknown: An error occurred`, so the normal transient `server_error` retry classification does not apply.
