### PR TITLE
feat: hide ambient Kilo UI for other providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ### Breaking Changes
 
-- Hide Kilo's custom footer, credit balance, and usage statuses by default when the selected model uses another provider. Set `display.showForOtherProviders` to `true` or `KILO_PI_SHOW_FOR_OTHER_PROVIDERS=1` to preserve the previous always-visible behavior.
+- Hide Kilo's custom footer, credit balance, and usage statuses by default when the selected model uses another provider ([#30](https://github.com/Kilo-Org/kilo-pi-provider/pull/30)). Set `display.showForOtherProviders` to `true` or `KILO_PI_SHOW_FOR_OTHER_PROVIDERS=1` to preserve the previous always-visible behavior.
 
 ### Added
 
-- Restore Kilo's custom footer and refresh configured credit and usage statuses immediately when switching back to a Kilo model.
+- Restore Kilo's custom footer and refresh configured credit and usage statuses immediately when switching back to a Kilo model ([#30](https://github.com/Kilo-Org/kilo-pi-provider/pull/30)).
 
 ### Fixed
 
-- Avoid presentation-related balance and usage requests while ambient Kilo UI is hidden, including provider changes during in-flight requests.
-- Classify malformed Kilo Responses failures that provide `error.type` without the required `error.code`.
+- Avoid presentation-related balance and usage requests while ambient Kilo UI is hidden, including provider changes during in-flight requests ([#30](https://github.com/Kilo-Org/kilo-pi-provider/pull/30)).
+- Classify malformed Kilo Responses failures that provide `error.type` without the required `error.code` ([#29](https://github.com/Kilo-Org/kilo-pi-provider/pull/29)).
 
 ## [2026.08.2] - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+## [2026.09.0] - 2026-09-03
+
+### Breaking Changes
+
+- Hide Kilo's custom footer, credit balance, and usage statuses by default when the selected model uses another provider. Set `display.showForOtherProviders` to `true` or `KILO_PI_SHOW_FOR_OTHER_PROVIDERS=1` to preserve the previous always-visible behavior.
+
+### Added
+
+- Restore Kilo's custom footer and refresh configured credit and usage statuses immediately when switching back to a Kilo model.
+
 ### Fixed
 
+- Avoid presentation-related balance and usage requests while ambient Kilo UI is hidden, including provider changes during in-flight requests.
 - Classify malformed Kilo Responses failures that provide `error.type` without the required `error.code`.
 
 ## [2026.08.2] - 2026-08-30

--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ You can also set `KILO_API_KEY` directly instead of using the login flow. Set `K
 
 ### Footer
 
-Kilo replaces Pi's footer by default to show usage and credits. To keep another extension's custom footer, disable Kilo's footer:
+When a Kilo model is selected, Kilo replaces Pi's footer by default to show usage and credits. Selecting a model from another provider restores Pi's footer and hides Kilo's ambient statuses. To keep Kilo's footer and statuses visible for models from other providers, set:
+
+```bash
+KILO_PI_SHOW_FOR_OTHER_PROVIDERS=1 pi
+```
+
+This setting controls only automatic footer and status presentation. It does not disable Kilo API access or explicitly invoked extension UI.
+
+To keep another extension's custom footer, disable Kilo's footer:
 
 ```bash
 KILO_PI_CUSTOM_FOOTER=0 pi
@@ -69,6 +77,7 @@ Set non-secret preferences globally in `~/.pi/agent/extensions/kilo-pi-provider/
 
 ```json
 {
+  "display": { "showForOtherProviders": false },
   "footer": { "custom": false },
   "credits": { "enabled": true },
   "usage": { "periods": ["day", "week"] }
@@ -76,6 +85,8 @@ Set non-secret preferences globally in `~/.pi/agent/extensions/kilo-pi-provider/
 ```
 
 A trusted project file overrides the global file, and environment variables override both. Project preferences are ignored until Pi trusts the project. Keep API keys and OAuth credentials out of these files.
+
+The `display.showForOtherProviders` preference defaults to `false` and is overridden by `KILO_PI_SHOW_FOR_OTHER_PROVIDERS`.
 
 Environment overrides are useful for one-off sessions:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.2",
+  "version": "2026.09.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilocode/kilo-pi-provider",
-      "version": "2026.08.2",
+      "version": "2026.09.0",
       "license": "BSL-1.0",
       "dependencies": {
         "typebox": "1.3.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.08.2",
+  "version": "2026.09.0",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ import Value from "typebox/value";
 export const KILO_USAGE_PERIODS = ["day", "week", "month", "year"] as const;
 export type KiloUsageDisplayPeriod = (typeof KILO_USAGE_PERIODS)[number];
 
+const DisplayPreferences = Type.Object({ showForOtherProviders: Type.Optional(Type.Boolean()) });
 const FooterPreferences = Type.Object({ custom: Type.Optional(Type.Boolean()) });
 const CreditsPreferences = Type.Object({ enabled: Type.Optional(Type.Boolean()) });
 const UsagePreferences = Type.Object({
@@ -16,12 +17,14 @@ const UsagePreferences = Type.Object({
 const PreferencesRoot = Type.Object({});
 
 export type KiloPreferences = {
+	display?: Type.Static<typeof DisplayPreferences>;
 	footer?: Type.Static<typeof FooterPreferences>;
 	credits?: Type.Static<typeof CreditsPreferences>;
 	usage?: Type.Static<typeof UsagePreferences>;
 };
 
 export type ResolvedKiloPreferences = {
+	display: { showForOtherProviders: boolean };
 	footer: { custom: boolean };
 	credits: { enabled: boolean };
 	usage: { periods: KiloUsageDisplayPeriod[] };
@@ -29,6 +32,7 @@ export type ResolvedKiloPreferences = {
 
 const CONFIG_DIRECTORY = "kilo-pi-provider";
 const DEFAULT_PREFERENCES: ResolvedKiloPreferences = {
+	display: { showForOtherProviders: false },
 	footer: { custom: true },
 	credits: { enabled: true },
 	usage: { periods: [] },
@@ -44,12 +48,18 @@ function readKiloPreferences(path: string): KiloPreferences {
 		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
 		if (!Value.Check(PreferencesRoot, parsed)) return {};
 
+		const display =
+			"display" in parsed && Value.Check(DisplayPreferences, parsed.display) ? parsed.display : undefined;
 		const footer = "footer" in parsed && Value.Check(FooterPreferences, parsed.footer) ? parsed.footer : undefined;
 		const credits =
 			"credits" in parsed && Value.Check(CreditsPreferences, parsed.credits) ? parsed.credits : undefined;
 		const usage = "usage" in parsed && Value.Check(UsagePreferences, parsed.usage) ? parsed.usage : undefined;
 
 		return {
+			display:
+				display?.showForOtherProviders === undefined
+					? undefined
+					: { showForOtherProviders: display.showForOtherProviders },
 			footer: footer?.custom === undefined ? undefined : { custom: footer.custom },
 			credits: credits?.enabled === undefined ? undefined : { enabled: credits.enabled },
 			usage: usage?.periods === undefined ? undefined : { periods: usage.periods },
@@ -87,6 +97,9 @@ function environmentUsagePeriods(value: string | undefined): KiloUsageDisplayPer
 
 export function getEnvironmentPreferences(environment: NodeJS.ProcessEnv = process.env): KiloPreferences {
 	return {
+		display: {
+			showForOtherProviders: environmentBoolean(environment.KILO_PI_SHOW_FOR_OTHER_PROVIDERS, false),
+		},
 		footer: { custom: environmentBoolean(environment.KILO_PI_CUSTOM_FOOTER, true) },
 		credits: { enabled: environmentBoolean(environment.KILO_PI_SHOW_CREDITS, true) },
 		usage: { periods: environmentUsagePeriods(environment.KILO_PI_USAGE) },
@@ -99,6 +112,13 @@ export function mergeKiloPreferences(
 	environment: KiloPreferences,
 ): ResolvedKiloPreferences {
 	return {
+		display: {
+			showForOtherProviders:
+				environment.display?.showForOtherProviders ??
+				project?.display?.showForOtherProviders ??
+				global.display?.showForOtherProviders ??
+				DEFAULT_PREFERENCES.display.showForOtherProviders,
+		},
 		footer: {
 			custom:
 				environment.footer?.custom ??

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,6 +331,8 @@ export default async function (pi: ExtensionAPI) {
 
 	// Refresh credits and opt-in usage after each turn.
 	pi.on("turn_end", async (_event, ctx) => {
+		if (!shouldShowAmbientKiloUi(ctx.model?.provider)) return;
+
 		const access = getKiloAccess();
 		const usagePeriods = preferences.usage.periods;
 		if (!access || !ctx.hasUI) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,13 @@ import { createUsageRefresher } from "./usage.ts";
 const KILO_GATEWAY_BASE = `${KILO_API_BASE}/api/gateway`;
 const MODELS_FETCH_TIMEOUT_MS = 10_000;
 const KILO_TOS_URL = "https://kilo.ai/terms";
+const KILO_STATUS_KEYS = [
+	"kilo-credits",
+	"kilo-usage-day",
+	"kilo-usage-week",
+	"kilo-usage-month",
+	"kilo-usage-year",
+] as const;
 
 function formatCredits(balance: number): string {
 	if (balance >= 1000) {
@@ -130,6 +137,13 @@ function makeProviderConfig(organizationId?: string) {
 export default async function (pi: ExtensionAPI) {
 	const startupAccess = getKiloAccess();
 	let preferences = loadKiloPreferences({ cwd: process.cwd(), projectTrusted: false });
+
+	const shouldShowAmbientKiloUi = (provider: string | undefined): boolean =>
+		provider === "kilo" || preferences.display.showForOtherProviders;
+
+	const clearAmbientKiloStatuses = (ctx: { ui: { setStatus(key: string, value: undefined): void } }): void => {
+		for (const key of KILO_STATUS_KEYS) ctx.ui.setStatus(key, undefined);
+	};
 
 	// Fetch models at load time so the provider is immediately usable for
 	// --list-models, --model selection, and print mode before session_start fires.
@@ -223,6 +237,11 @@ export default async function (pi: ExtensionAPI) {
 		});
 		const access = getKiloAccess();
 		const usagePeriods = preferences.usage.periods;
+
+		if (ctx.hasUI && !shouldShowAmbientKiloUi(ctx.model?.provider)) {
+			clearAmbientKiloStatuses(ctx);
+			return;
+		}
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
@@ -345,6 +364,8 @@ export default async function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
-		if (preferences.footer.custom) installCustomFooter(pi, ctx, preferences.credits.enabled);
+		if (preferences.footer.custom && shouldShowAmbientKiloUi(ctx.model?.provider)) {
+			installCustomFooter(pi, ctx, preferences.credits.enabled);
+		}
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,7 @@ export default async function (pi: KiloExtensionApi) {
 		const access = getKiloAccess();
 		const usagePeriods = preferences.usage.periods;
 		const showAmbientUi = reconcileAmbientKiloUi(ctx, ctx.model?.provider);
+		const sessionStartRevision = ambientUiRevision;
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
@@ -303,7 +304,9 @@ export default async function (pi: KiloExtensionApi) {
 		}
 
 		// Fetch and display credits balance when enabled and an interactive UI is available.
-		if (showAmbientUi && ctx.hasUI && preferences.credits.enabled) {
+		const ambientUiIsCurrent =
+			sessionStartRevision === ambientUiRevision && shouldShowAmbientKiloUi(ctx.model?.provider);
+		if (showAmbientUi && ambientUiIsCurrent && ctx.hasUI && preferences.credits.enabled) {
 			const revision = ambientUiRevision;
 			try {
 				const balance = await fetchKiloBalance(access.token, access.organizationId);
@@ -314,7 +317,7 @@ export default async function (pi: KiloExtensionApi) {
 		}
 	});
 
-	// Update credits display when model changes to a Kilo model
+	// Reconcile and refresh ambient Kilo UI when the selected model changes.
 	pi.on("model_select", async (event, ctx) => {
 		if (!reconcileAmbientKiloUi(ctx, event.model.provider)) return;
 		if (event.model.provider !== "kilo" && !preferences.display.showForOtherProviders) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,9 @@ function makeProviderConfig(organizationId?: string) {
 // Extension Entry Point
 // =============================================================================
 
-export default async function (pi: ExtensionAPI) {
+export type KiloExtensionApi = Pick<ExtensionAPI, "getThinkingLevel" | "on" | "registerProvider">;
+
+export default async function (pi: KiloExtensionApi) {
 	const startupAccess = getKiloAccess();
 	let preferences = loadKiloPreferences({ cwd: process.cwd(), projectTrusted: false });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export default async function (pi: ExtensionAPI) {
 	let preferences = loadKiloPreferences({ cwd: process.cwd(), projectTrusted: false });
 
 	let kiloFooterInstalled = false;
+	let ambientUiRevision = 0;
 	const shouldShowAmbientKiloUi = (provider: string | undefined): boolean =>
 		provider === "kilo" || preferences.display.showForOtherProviders;
 
@@ -147,6 +148,7 @@ export default async function (pi: ExtensionAPI) {
 	};
 
 	const reconcileAmbientKiloUi = (ctx: ExtensionContext, provider: string | undefined): boolean => {
+		ambientUiRevision += 1;
 		const visible = shouldShowAmbientKiloUi(provider);
 		if (!ctx.hasUI) return visible;
 
@@ -163,6 +165,11 @@ export default async function (pi: ExtensionAPI) {
 			clearAmbientKiloStatuses(ctx);
 		}
 		return visible;
+	};
+
+	const publishCredits = (ctx: ExtensionContext, balance: number, revision: number): void => {
+		if (revision !== ambientUiRevision || !shouldShowAmbientKiloUi(ctx.model?.provider)) return;
+		ctx.ui.setStatus("kilo-credits", ctx.ui.theme.fg("accent", `💰 ${formatCredits(balance)}`));
 	};
 
 	// Fetch models at load time so the provider is immediately usable for
@@ -296,12 +303,10 @@ export default async function (pi: ExtensionAPI) {
 
 		// Fetch and display credits balance when enabled and an interactive UI is available.
 		if (ctx.hasUI && preferences.credits.enabled) {
+			const revision = ambientUiRevision;
 			try {
 				const balance = await fetchKiloBalance(access.token, access.organizationId);
-				if (balance !== null) {
-					const theme = ctx.ui.theme;
-					ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));
-				}
+				if (balance !== null) publishCredits(ctx, balance, revision);
 			} catch (error) {
 				console.warn("[kilo] Failed to fetch balance:", error instanceof Error ? error.message : error);
 			}
@@ -318,12 +323,10 @@ export default async function (pi: ExtensionAPI) {
 
 		if (!ctx.hasUI || !preferences.credits.enabled) return;
 
+		const revision = ambientUiRevision;
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
-			if (balance !== null) {
-				const theme = ctx.ui.theme;
-				ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));
-			}
+			if (balance !== null) publishCredits(ctx, balance, revision);
 		} catch (error) {
 			console.warn(
 				"[kilo] Failed to fetch balance on model select:",
@@ -349,12 +352,10 @@ export default async function (pi: ExtensionAPI) {
 
 		if (!preferences.credits.enabled) return;
 
+		const revision = ambientUiRevision;
 		try {
 			const balance = await fetchKiloBalance(access.token, access.organizationId);
-			if (balance !== null) {
-				const theme = ctx.ui.theme;
-				ctx.ui.setStatus("kilo-credits", theme.fg("accent", `💰 ${formatCredits(balance)}`));
-			}
+			if (balance !== null) publishCredits(ctx, balance, revision);
 		} catch (error) {
 			console.warn("[kilo] Failed to fetch balance on turn end:", error instanceof Error ? error.message : error);
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,10 @@ export default async function (pi: ExtensionAPI) {
 			kiloFooterInstalled = false;
 		}
 
-		if (!visible) clearAmbientKiloStatuses(ctx);
+		if (!visible) {
+			usageRefresher.invalidate();
+			clearAmbientKiloStatuses(ctx);
+		}
 		return visible;
 	};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { isFreeModel, mapOpenRouterModel, type OpenRouterModel, parsePrice } fro
 
 export { parsePrice };
 
-import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import {
 	fetchKiloBalance,
 	fetchKiloUsageEntries,
@@ -138,11 +138,28 @@ export default async function (pi: ExtensionAPI) {
 	const startupAccess = getKiloAccess();
 	let preferences = loadKiloPreferences({ cwd: process.cwd(), projectTrusted: false });
 
+	let kiloFooterInstalled = false;
 	const shouldShowAmbientKiloUi = (provider: string | undefined): boolean =>
 		provider === "kilo" || preferences.display.showForOtherProviders;
 
-	const clearAmbientKiloStatuses = (ctx: { ui: { setStatus(key: string, value: undefined): void } }): void => {
+	const clearAmbientKiloStatuses = (ctx: ExtensionContext): void => {
 		for (const key of KILO_STATUS_KEYS) ctx.ui.setStatus(key, undefined);
+	};
+
+	const reconcileAmbientKiloUi = (ctx: ExtensionContext, provider: string | undefined): boolean => {
+		const visible = shouldShowAmbientKiloUi(provider);
+		if (!ctx.hasUI) return visible;
+
+		if (visible && preferences.footer.custom && !kiloFooterInstalled) {
+			installCustomFooter(pi, ctx, preferences.credits.enabled);
+			kiloFooterInstalled = true;
+		} else if ((!visible || !preferences.footer.custom) && kiloFooterInstalled) {
+			ctx.ui.setFooter(undefined);
+			kiloFooterInstalled = false;
+		}
+
+		if (!visible) clearAmbientKiloStatuses(ctx);
+		return visible;
 	};
 
 	// Fetch models at load time so the provider is immediately usable for
@@ -238,10 +255,7 @@ export default async function (pi: ExtensionAPI) {
 		const access = getKiloAccess();
 		const usagePeriods = preferences.usage.periods;
 
-		if (ctx.hasUI && !shouldShowAmbientKiloUi(ctx.model?.provider)) {
-			clearAmbientKiloStatuses(ctx);
-			return;
-		}
+		if (!reconcileAmbientKiloUi(ctx, ctx.model?.provider)) return;
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
@@ -293,7 +307,8 @@ export default async function (pi: ExtensionAPI) {
 
 	// Update credits display when model changes to a Kilo model
 	pi.on("model_select", async (event, ctx) => {
-		if (event.model?.provider !== "kilo") return;
+		if (!reconcileAmbientKiloUi(ctx, event.model.provider)) return;
+		if (event.model.provider !== "kilo" && !preferences.display.showForOtherProviders) return;
 
 		const access = getKiloAccess();
 		if (!access) return;
@@ -361,11 +376,5 @@ export default async function (pi: ExtensionAPI) {
 				display: true,
 			},
 		};
-	});
-
-	pi.on("session_start", async (_event, ctx) => {
-		if (preferences.footer.custom && shouldShowAmbientKiloUi(ctx.model?.provider)) {
-			installCustomFooter(pi, ctx, preferences.credits.enabled);
-		}
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,8 +264,7 @@ export default async function (pi: ExtensionAPI) {
 		});
 		const access = getKiloAccess();
 		const usagePeriods = preferences.usage.periods;
-
-		if (!reconcileAmbientKiloUi(ctx, ctx.model?.provider)) return;
+		const showAmbientUi = reconcileAmbientKiloUi(ctx, ctx.model?.provider);
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
@@ -273,7 +272,7 @@ export default async function (pi: ExtensionAPI) {
 			return;
 		}
 
-		if (ctx.hasUI && usagePeriods.length > 0) {
+		if (showAmbientUi && ctx.hasUI && usagePeriods.length > 0) {
 			usageRefresher.refresh(access, usagePeriods, {
 				setStatus: (key, value) => ctx.ui.setStatus(key, value),
 				accent: (text) => ctx.ui.theme.fg("accent", text),
@@ -302,7 +301,7 @@ export default async function (pi: ExtensionAPI) {
 		}
 
 		// Fetch and display credits balance when enabled and an interactive UI is available.
-		if (ctx.hasUI && preferences.credits.enabled) {
+		if (showAmbientUi && ctx.hasUI && preferences.credits.enabled) {
 			const revision = ambientUiRevision;
 			try {
 				const balance = await fetchKiloBalance(access.token, access.organizationId);

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,9 +318,17 @@ export default async function (pi: ExtensionAPI) {
 		if (event.model.provider !== "kilo" && !preferences.display.showForOtherProviders) return;
 
 		const access = getKiloAccess();
-		if (!access) return;
+		if (!access || !ctx.hasUI) return;
 
-		if (!ctx.hasUI || !preferences.credits.enabled) return;
+		const usagePeriods = preferences.usage.periods;
+		if (usagePeriods.length > 0) {
+			usageRefresher.refresh(access, usagePeriods, {
+				setStatus: (key, value) => ctx.ui.setStatus(key, value),
+				accent: (text) => ctx.ui.theme.fg("accent", text),
+			});
+		}
+
+		if (!preferences.credits.enabled) return;
 
 		const revision = ambientUiRevision;
 		try {

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -104,6 +104,10 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 	}
 
 	return {
+		invalidate(): void {
+			revision += 1;
+			queued = undefined;
+		},
 		refresh(access: KiloAccess, periods: KiloUsageDisplayPeriod[], presentation: UsageStatusPresentation): void {
 			if (periods.length === 0) return;
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -18,7 +18,12 @@ test("merges global, project, and environment preferences in precedence order", 
 			{ credits: { enabled: true } },
 			{ credits: { enabled: false }, usage: { periods: ["day", "month"] } },
 		),
-	).toEqual({ footer: { custom: false }, credits: { enabled: false }, usage: { periods: ["day", "month"] } });
+	).toEqual({
+		display: { showForOtherProviders: false },
+		footer: { custom: false },
+		credits: { enabled: false },
+		usage: { periods: ["day", "month"] },
+	});
 });
 
 test("hides ambient Kilo UI for other providers by default", () => {
@@ -72,6 +77,7 @@ describe("loadKiloPreferences", () => {
 		writeConfig(join(cwd, ".pi"), { credits: { enabled: true }, usage: { periods: ["day", "month"] } });
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: true, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: true },
 			credits: { enabled: true },
 			usage: { periods: ["day", "month"] },
@@ -91,7 +97,12 @@ describe("loadKiloPreferences", () => {
 				projectTrusted: false,
 				environment: { KILO_PI_SHOW_CREDITS: "true", KILO_PI_CUSTOM_FOOTER: "0", KILO_PI_USAGE: "day,week" },
 			}),
-		).toEqual({ footer: { custom: false }, credits: { enabled: true }, usage: { periods: ["day", "week"] } });
+		).toEqual({
+			display: { showForOtherProviders: false },
+			footer: { custom: false },
+			credits: { enabled: true },
+			usage: { periods: ["day", "week"] },
+		});
 	});
 
 	test("ignores nested values that are not objects", () => {
@@ -100,6 +111,7 @@ describe("loadKiloPreferences", () => {
 		writeConfig(agentDirectory, { footer: true, credits: [], usage: "day" });
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: true },
 			credits: { enabled: true },
 			usage: { periods: [] },
@@ -116,6 +128,7 @@ describe("loadKiloPreferences", () => {
 		});
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: false },
 			credits: { enabled: true },
 			usage: { periods: [] },
@@ -133,6 +146,7 @@ describe("loadKiloPreferences", () => {
 		});
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: false },
 			credits: { enabled: false },
 			usage: { periods: [] },
@@ -145,6 +159,7 @@ describe("loadKiloPreferences", () => {
 		writeConfig(agentDirectory, { footer: {}, credits: {}, usage: {} });
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: true },
 			credits: { enabled: true },
 			usage: { periods: [] },
@@ -157,6 +172,7 @@ describe("loadKiloPreferences", () => {
 		writeConfig(agentDirectory, config);
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: false, environment: {} })).toEqual({
+			display: { showForOtherProviders: false },
 			footer: { custom: true },
 			credits: { enabled: true },
 			usage: { periods: [] },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,9 +14,18 @@ afterEach(() => {
 test("merges global, project, and environment preferences in precedence order", () => {
 	expect(
 		mergeKiloPreferences(
-			{ footer: { custom: false }, credits: { enabled: false }, usage: { periods: ["week"] } },
-			{ credits: { enabled: true } },
-			{ credits: { enabled: false }, usage: { periods: ["day", "month"] } },
+			{
+				display: { showForOtherProviders: false },
+				footer: { custom: false },
+				credits: { enabled: false },
+				usage: { periods: ["week"] },
+			},
+			{ display: { showForOtherProviders: true }, credits: { enabled: true } },
+			{
+				display: { showForOtherProviders: false },
+				credits: { enabled: false },
+				usage: { periods: ["day", "month"] },
+			},
 		),
 	).toEqual({
 		display: { showForOtherProviders: false },
@@ -73,11 +82,19 @@ describe("loadKiloPreferences", () => {
 	test("uses trusted project preferences over global preferences", () => {
 		const agentDirectory = createDirectory();
 		const cwd = createDirectory();
-		writeConfig(agentDirectory, { credits: { enabled: false }, usage: { periods: ["week"] } });
-		writeConfig(join(cwd, ".pi"), { credits: { enabled: true }, usage: { periods: ["day", "month"] } });
+		writeConfig(agentDirectory, {
+			display: { showForOtherProviders: false },
+			credits: { enabled: false },
+			usage: { periods: ["week"] },
+		});
+		writeConfig(join(cwd, ".pi"), {
+			display: { showForOtherProviders: true },
+			credits: { enabled: true },
+			usage: { periods: ["day", "month"] },
+		});
 
 		expect(loadKiloPreferences({ agentDirectory, cwd, projectTrusted: true, environment: {} })).toEqual({
-			display: { showForOtherProviders: false },
+			display: { showForOtherProviders: true },
 			footer: { custom: true },
 			credits: { enabled: true },
 			usage: { periods: ["day", "month"] },
@@ -87,15 +104,20 @@ describe("loadKiloPreferences", () => {
 	test("ignores untrusted project preferences and lets environment override config", () => {
 		const agentDirectory = createDirectory();
 		const cwd = createDirectory();
-		writeConfig(agentDirectory, { credits: { enabled: false } });
-		writeConfig(join(cwd, ".pi"), { credits: { enabled: true } });
+		writeConfig(agentDirectory, { display: { showForOtherProviders: true }, credits: { enabled: false } });
+		writeConfig(join(cwd, ".pi"), { display: { showForOtherProviders: false }, credits: { enabled: true } });
 
 		expect(
 			loadKiloPreferences({
 				agentDirectory,
 				cwd,
 				projectTrusted: false,
-				environment: { KILO_PI_SHOW_CREDITS: "true", KILO_PI_CUSTOM_FOOTER: "0", KILO_PI_USAGE: "day,week" },
+				environment: {
+					KILO_PI_SHOW_FOR_OTHER_PROVIDERS: "0",
+					KILO_PI_SHOW_CREDITS: "true",
+					KILO_PI_CUSTOM_FOOTER: "0",
+					KILO_PI_USAGE: "day,week",
+				},
 			}),
 		).toEqual({
 			display: { showForOtherProviders: false },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,6 +21,10 @@ test("merges global, project, and environment preferences in precedence order", 
 	).toEqual({ footer: { custom: false }, credits: { enabled: false }, usage: { periods: ["day", "month"] } });
 });
 
+test("hides ambient Kilo UI for other providers by default", () => {
+	expect(mergeKiloPreferences({}, undefined, {}).display.showForOtherProviders).toBe(false);
+});
+
 test.each([
 	["KILO_PI_USAGE=day,week", { KILO_PI_USAGE: "day,week" }, ["day", "week"]],
 	["legacy truthy KILO_PI_USAGE", { KILO_PI_USAGE: "true" }, ["day"]],
@@ -28,6 +32,16 @@ test.each([
 ])("parses %s", (_name, environment, periods) => {
 	expect(getEnvironmentPreferences(environment).usage?.periods).toEqual(periods);
 });
+
+test.each(["1", "true", "yes"])(
+	"KILO_PI_SHOW_FOR_OTHER_PROVIDERS=%s shows ambient Kilo UI for other providers",
+	(value) => {
+		expect(
+			mergeKiloPreferences({}, undefined, getEnvironmentPreferences({ KILO_PI_SHOW_FOR_OTHER_PROVIDERS: value }))
+				.display.showForOtherProviders,
+		).toBe(true);
+	},
+);
 
 test("uses defaults for unrecognized boolean environment values", () => {
 	expect(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -475,6 +475,26 @@ test("turn_end schedules an enabled daily usage refresh", async () => {
 	});
 });
 
+test("switching providers prevents an in-flight usage refresh from republishing status", async () => {
+	vi.stubEnv("KILO_PI_USAGE", "day");
+	const usageResponse = deferred<Response>();
+	const runtime = createRuntime({ apiKey: "api-key", usageResponse: usageResponse.promise });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+	runtime.context.model.provider = "other";
+	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
+
+	usageResponse.resolve(
+		new Response(
+			JSON.stringify({ usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 3_000_000 }] }),
+			{ status: 200 },
+		),
+	);
+	await new Promise<void>((resolve) => setImmediate(resolve));
+	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-usage-day", "💸 $3.00 today");
+});
+
 test("turn_end does not wait for an enabled usage response", async () => {
 	vi.stubEnv("KILO_PI_USAGE", "day");
 	const usageResponse = deferred<Response>();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "0");
 	vi.stubEnv("KILO_PI_SHOW_CREDITS", "");
 	vi.stubEnv("KILO_PI_USAGE", "");
+	vi.stubEnv("KILO_PI_SHOW_FOR_OTHER_PROVIDERS", "");
 });
 
 afterEach(() => {
@@ -78,7 +79,7 @@ async function customFooterWasInstalled(customFooter: string): Promise<boolean> 
 	const sessionStartHandlers = on.mock.calls
 		.filter(([event]) => event === "session_start")
 		.map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
-	const context = { hasUI: true, ui: { setFooter, setStatus: vi.fn() } };
+	const context = { model: { provider: "kilo" }, hasUI: true, ui: { setFooter, setStatus: vi.fn() } };
 	await Promise.all(sessionStartHandlers.map((handler) => handler({}, context)));
 
 	return setFooter.mock.calls.length > 0;
@@ -90,6 +91,22 @@ test("does not install the custom footer when disabled", async () => {
 
 test("installs the custom footer by default", async () => {
 	await expect(customFooterWasInstalled("")).resolves.toBe(true);
+});
+
+test("hides ambient Kilo UI at startup for another provider", async () => {
+	const runtime = createRuntime({ apiKey: "api-key", provider: "other" });
+	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "1");
+	vi.stubEnv("KILO_PI_USAGE", "day");
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await Promise.all(handlers(runtime.on, "session_start").map((run) => run({}, runtime.context)));
+
+	expect(runtime.context.ui.setFooter).toHaveBeenCalledWith(undefined);
+	for (const key of ["kilo-credits", "kilo-usage-day", "kilo-usage-week", "kilo-usage-month", "kilo-usage-year"]) {
+		expect(runtime.setStatus).toHaveBeenCalledWith(key, undefined);
+	}
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).endsWith("/balance"))).toBe(false);
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(false);
 });
 
 test("exposes Kilo credits when the custom footer is disabled", async () => {
@@ -219,6 +236,10 @@ test("loads the organization catalog with KILO_API_KEY", async () => {
 
 type ExtensionHandler = (event: unknown, context: unknown) => Promise<unknown>;
 
+function handlers(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler[] {
+	return on.mock.calls.filter(([name]) => name === event).map(([, run]) => run as ExtensionHandler);
+}
+
 function handler(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler {
 	const registered = on.mock.calls.find(([name]) => name === event)?.[1] as ExtensionHandler | undefined;
 	if (!registered) throw new Error(`${event} handler not registered`);
@@ -233,6 +254,7 @@ function createRuntime(
 		balance?: number;
 		usage?: unknown;
 		usageResponse?: Promise<Response>;
+		provider?: string;
 	} = {},
 ) {
 	if (options.auth) setAuth(options.auth);
@@ -252,8 +274,9 @@ function createRuntime(
 	const on = vi.fn();
 	const setStatus = vi.fn();
 	const context = {
+		model: { provider: options.provider ?? "kilo" },
 		hasUI: true,
-		ui: { setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
+		ui: { setFooter: vi.fn(), setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
 		modelRegistry: { registerProvider: vi.fn() },
 	};
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -76,11 +76,8 @@ async function customFooterWasInstalled(customFooter: string): Promise<boolean> 
 	const setFooter = vi.fn();
 	await kiloExtension(extensionApi(vi.fn(), on));
 
-	const sessionStartHandlers = on.mock.calls
-		.filter(([event]) => event === "session_start")
-		.map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
 	const context = { model: { provider: "kilo" }, hasUI: true, ui: { setFooter, setStatus: vi.fn() } };
-	await Promise.all(sessionStartHandlers.map((handler) => handler({}, context)));
+	await Promise.all(handlers(on, "session_start").map((run) => run({}, context)));
 
 	return setFooter.mock.calls.length > 0;
 }
@@ -165,16 +162,13 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 	const setStatus = vi.fn();
 	await kiloExtension(extensionApi(vi.fn(), on));
 
-	const sessionStartHandlers = on.mock.calls
-		.filter(([event]) => event === "session_start")
-		.map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
 	const context = {
 		model: { provider: "kilo" },
 		hasUI: true,
 		ui: { setFooter: vi.fn(), setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
 		modelRegistry: { registerProvider: vi.fn() },
 	};
-	await Promise.all(sessionStartHandlers.map((handler) => handler({}, context)));
+	await Promise.all(handlers(on, "session_start").map((run) => run({}, context)));
 
 	expect(setStatus).toHaveBeenCalledWith("kilo-credits", "💰 $12.34");
 	expect(context.ui.setFooter).not.toHaveBeenCalled();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -367,7 +367,7 @@ test.each([
 test.each([
 	["session_start", {}, {}, {}, 1, "kilo-credits"],
 	["session_start", {}, { apiKey: "api-key" }, { hasUI: false }, 2, undefined],
-	["model_select", { model: { provider: "other" } }, { apiKey: "api-key" }, {}, 1, undefined],
+	["model_select", { model: { provider: "other" } }, { apiKey: "api-key" }, {}, 1, "kilo-credits"],
 	["turn_end", {}, { apiKey: "api-key" }, { hasUI: false }, 1, undefined],
 ])(
 	"%s skips credit work when access, UI, or Kilo model requirements are unmet",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -109,6 +109,25 @@ test("hides ambient Kilo UI at startup for another provider", async () => {
 	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(false);
 });
 
+test("model selection hides and restores ambient Kilo UI", async () => {
+	const runtime = createRuntime({ apiKey: "api-key" });
+	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "1");
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await Promise.all(handlers(runtime.on, "session_start").map((run) => run({}, runtime.context)));
+	expect(runtime.context.ui.setFooter).toHaveBeenLastCalledWith(expect.any(Function));
+
+	runtime.context.model.provider = "other";
+	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
+	expect(runtime.context.ui.setFooter).toHaveBeenLastCalledWith(undefined);
+	expect(runtime.setStatus).toHaveBeenCalledWith("kilo-credits", undefined);
+
+	runtime.context.model.provider = "kilo";
+	await handler(runtime.on, "model_select")({ model: { provider: "kilo" } }, runtime.context);
+	expect(runtime.context.ui.setFooter).toHaveBeenLastCalledWith(expect.any(Function));
+	expect(runtime.setStatus).toHaveBeenLastCalledWith("kilo-credits", "💰 $12.34");
+});
+
 test("exposes Kilo credits when the custom footer is disabled", async () => {
 	setAuth({ kilo: { type: "oauth", access: "stored-access-token" } });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -101,7 +101,7 @@ test("hides ambient Kilo UI at startup for another provider", async () => {
 	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
 	await Promise.all(handlers(runtime.on, "session_start").map((run) => run({}, runtime.context)));
 
-	expect(runtime.context.ui.setFooter).toHaveBeenCalledWith(undefined);
+	expect(runtime.context.ui.setFooter).not.toHaveBeenCalled();
 	for (const key of ["kilo-credits", "kilo-usage-day", "kilo-usage-week", "kilo-usage-month", "kilo-usage-year"]) {
 		expect(runtime.setStatus).toHaveBeenCalledWith(key, undefined);
 	}
@@ -132,6 +132,7 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 		.filter(([event]) => event === "session_start")
 		.map(([, handler]) => handler as (event: unknown, context: unknown) => Promise<void>);
 	const context = {
+		model: { provider: "kilo" },
 		hasUI: true,
 		ui: { setFooter: vi.fn(), setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
 		modelRegistry: { registerProvider: vi.fn() },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -129,6 +129,23 @@ test("model selection hides and restores ambient Kilo UI", async () => {
 	expect(runtime.setStatus).toHaveBeenLastCalledWith("kilo-credits", "💰 $12.34");
 });
 
+test("selecting a Kilo model immediately restores configured usage status", async () => {
+	vi.stubEnv("KILO_PI_USAGE", "day");
+	const runtime = createRuntime({
+		apiKey: "api-key",
+		provider: "other",
+		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 4_000_000 }] },
+	});
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	runtime.context.model.provider = "kilo";
+	await handler(runtime.on, "model_select")({ model: { provider: "kilo" } }, runtime.context);
+
+	await vi.waitFor(() => {
+		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $4.00 today");
+	});
+});
+
 test("exposes Kilo credits when the custom footer is disabled", async () => {
 	setAuth({ kilo: { type: "oauth", access: "stored-access-token" } });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -272,6 +272,7 @@ function createRuntime(
 		apiKey?: string;
 		organizationId?: string;
 		balance?: number;
+		balanceResponse?: Promise<Response>;
 		usage?: unknown;
 		usageResponse?: Promise<Response>;
 		provider?: string;
@@ -283,7 +284,10 @@ function createRuntime(
 	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
 		const url = String(input);
 		if (url.endsWith("/balance")) {
-			return new Response(JSON.stringify({ balance: options.balance ?? 12.34 }), { status: 200 });
+			return (
+				options.balanceResponse ??
+				new Response(JSON.stringify({ balance: options.balance ?? 12.34 }), { status: 200 })
+			);
 		}
 		if (url.includes("/usage?")) {
 			return options.usageResponse ?? new Response(JSON.stringify(options.usage ?? { usage: [] }), { status: 200 });
@@ -473,6 +477,20 @@ test("turn_end schedules an enabled daily usage refresh", async () => {
 	await vi.waitFor(() => {
 		expect(runtime.setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $2.00 today");
 	});
+});
+
+test("switching providers prevents an in-flight balance refresh from republishing status", async () => {
+	const balanceResponse = deferred<Response>();
+	const runtime = createRuntime({ apiKey: "api-key", balanceResponse: balanceResponse.promise });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	const turnEnd = handler(runtime.on, "turn_end")({}, runtime.context);
+	runtime.context.model.provider = "other";
+	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
+
+	balanceResponse.resolve(new Response(JSON.stringify({ balance: 99.99 }), { status: 200 }));
+	await turnEnd;
+	expect(runtime.setStatus).not.toHaveBeenCalledWith("kilo-credits", "💰 $99.99");
 });
 
 test("switching providers prevents an in-flight usage refresh from republishing status", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -438,6 +438,28 @@ test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes"
 	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?period=week"))).toBe(true);
 });
 
+test("turn_end skips ambient API calls for another provider", async () => {
+	vi.stubEnv("KILO_PI_USAGE", "day");
+	const runtime = createRuntime({ apiKey: "api-key", provider: "other" });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+
+	expect(runtime.fetchMock).toHaveBeenCalledTimes(1);
+	expect(runtime.setStatus).not.toHaveBeenCalled();
+});
+
+test("the display override keeps turn-related ambient API calls enabled", async () => {
+	vi.stubEnv("KILO_PI_SHOW_FOR_OTHER_PROVIDERS", "1");
+	vi.stubEnv("KILO_PI_USAGE", "day");
+	const runtime = createRuntime({ apiKey: "api-key", provider: "other" });
+
+	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await handler(runtime.on, "turn_end")({}, runtime.context);
+
+	await vi.waitFor(() => expect(runtime.fetchMock).toHaveBeenCalledTimes(3));
+});
+
 test("turn_end schedules an enabled daily usage refresh", async () => {
 	vi.stubEnv("KILO_PI_USAGE", "day");
 	const runtime = createRuntime({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -105,6 +105,7 @@ test("hides ambient Kilo UI at startup for another provider", async () => {
 	for (const key of ["kilo-credits", "kilo-usage-day", "kilo-usage-week", "kilo-usage-month", "kilo-usage-year"]) {
 		expect(runtime.setStatus).toHaveBeenCalledWith(key, undefined);
 	}
+	expect(runtime.fetchMock.mock.calls.filter(([url]) => String(url).endsWith("/models"))).toHaveLength(2);
 	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).endsWith("/balance"))).toBe(false);
 	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(false);
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
-import kiloExtension, { parsePrice } from "../src/index.ts";
+import kiloExtension, { type KiloExtensionApi, parsePrice } from "../src/index.ts";
 
 const temporaryDirectories: string[] = [];
 let agentDirectory: string;
@@ -74,7 +74,7 @@ async function customFooterWasInstalled(customFooter: string): Promise<boolean> 
 
 	const on = vi.fn();
 	const setFooter = vi.fn();
-	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await kiloExtension(extensionApi(vi.fn(), on));
 
 	const sessionStartHandlers = on.mock.calls
 		.filter(([event]) => event === "session_start")
@@ -98,7 +98,7 @@ test("hides ambient Kilo UI at startup for another provider", async () => {
 	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "1");
 	vi.stubEnv("KILO_PI_USAGE", "day");
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await Promise.all(handlers(runtime.on, "session_start").map((run) => run({}, runtime.context)));
 
 	expect(runtime.context.ui.setFooter).not.toHaveBeenCalled();
@@ -114,7 +114,7 @@ test("model selection hides and restores ambient Kilo UI", async () => {
 	const runtime = createRuntime({ apiKey: "api-key" });
 	vi.stubEnv("KILO_PI_CUSTOM_FOOTER", "1");
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await Promise.all(handlers(runtime.on, "session_start").map((run) => run({}, runtime.context)));
 	expect(runtime.context.ui.setFooter).toHaveBeenLastCalledWith(expect.any(Function));
 
@@ -137,7 +137,7 @@ test("selecting a Kilo model immediately restores configured usage status", asyn
 		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 4_000_000 }] },
 	});
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	runtime.context.model.provider = "kilo";
 	await handler(runtime.on, "model_select")({ model: { provider: "kilo" } }, runtime.context);
 
@@ -163,7 +163,7 @@ test("exposes Kilo credits when the custom footer is disabled", async () => {
 
 	const on = vi.fn();
 	const setStatus = vi.fn();
-	await kiloExtension({ registerProvider: vi.fn(), on } as never);
+	await kiloExtension(extensionApi(vi.fn(), on));
 
 	const sessionStartHandlers = on.mock.calls
 		.filter(([event]) => event === "session_start")
@@ -186,7 +186,7 @@ test("does not fetch or display credits when KILO_PI_SHOW_CREDITS is disabled", 
 	mkdirSync(configDirectory, { recursive: true });
 	writeFileSync(join(configDirectory, "config.json"), JSON.stringify({ credits: { enabled: false } }));
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "session_start")({}, runtime.context);
 	await handler(runtime.on, "model_select")({ model: { provider: "kilo" } }, runtime.context);
 	await handler(runtime.on, "turn_end")({}, runtime.context);
@@ -202,7 +202,7 @@ test("registers anonymous free models from the Kilo catalog", async () => {
 	const registerProvider = vi.fn();
 	const on = vi.fn();
 
-	await kiloExtension({ registerProvider, on } as never);
+	await kiloExtension(extensionApi(registerProvider, on));
 
 	expect(fetchMock).toHaveBeenCalledOnce();
 	expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.kilo.ai/api/gateway/models");
@@ -236,7 +236,7 @@ test("loads the organization catalog with stored OAuth credentials", async () =>
 	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
 	vi.stubGlobal("fetch", fetchMock);
 
-	await kiloExtension({ registerProvider: vi.fn(), on: vi.fn() } as never);
+	await kiloExtension(extensionApi(vi.fn(), vi.fn()));
 
 	expect(fetchMock).toHaveBeenCalledOnce();
 	expect(fetchMock).toHaveBeenCalledWith(
@@ -258,7 +258,7 @@ test("loads the organization catalog with KILO_API_KEY", async () => {
 	const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(catalogResponse());
 	vi.stubGlobal("fetch", fetchMock);
 
-	await kiloExtension({ registerProvider: vi.fn(), on: vi.fn() } as never);
+	await kiloExtension(extensionApi(vi.fn(), vi.fn()));
 
 	expect(fetchMock).toHaveBeenCalledOnce();
 	expect(fetchMock).toHaveBeenCalledWith(
@@ -274,14 +274,27 @@ test("loads the organization catalog with KILO_API_KEY", async () => {
 
 type ExtensionHandler = (event: unknown, context: unknown) => Promise<unknown>;
 
-function handlers(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler[] {
-	return on.mock.calls.filter(([name]) => name === event).map(([, run]) => run as ExtensionHandler);
+type ExtensionOn = ReturnType<typeof vi.fn>;
+type RegisterProvider = ReturnType<typeof vi.fn>;
+
+function extensionApi(registerProvider: RegisterProvider, on: ExtensionOn): KiloExtensionApi {
+	// SAFETY: these spies implement the extension methods used during initialization; calls are verified by the tests.
+	return { registerProvider, on, getThinkingLevel: vi.fn() } as KiloExtensionApi;
 }
 
-function handler(on: ReturnType<typeof vi.fn>, event: string): ExtensionHandler {
-	const registered = on.mock.calls.find(([name]) => name === event)?.[1] as ExtensionHandler | undefined;
+function extensionHandler(run: ReturnType<typeof vi.fn>): ExtensionHandler {
+	// SAFETY: every recorded second argument comes from pi.on and is therefore an extension event handler.
+	return run as ExtensionHandler;
+}
+
+function handlers(on: ExtensionOn, event: string): ExtensionHandler[] {
+	return on.mock.calls.filter(([name]) => name === event).map(([, run]) => extensionHandler(run));
+}
+
+function handler(on: ExtensionOn, event: string): ExtensionHandler {
+	const registered = on.mock.calls.find(([name]) => name === event)?.[1];
 	if (!registered) throw new Error(`${event} handler not registered`);
-	return registered;
+	return extensionHandler(registered);
 }
 
 function createRuntime(
@@ -291,6 +304,7 @@ function createRuntime(
 		organizationId?: string;
 		balance?: number;
 		balanceResponse?: Promise<Response>;
+		sessionCatalogResponse?: Promise<Response>;
 		usage?: unknown;
 		usageResponse?: Promise<Response>;
 		provider?: string;
@@ -299,6 +313,7 @@ function createRuntime(
 	if (options.auth) setAuth(options.auth);
 	vi.stubEnv("KILO_API_KEY", options.apiKey ?? "");
 	vi.stubEnv("KILO_ORG_ID", options.organizationId ?? "");
+	let catalogRequestCount = 0;
 	const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
 		const url = String(input);
 		if (url.endsWith("/balance")) {
@@ -310,6 +325,8 @@ function createRuntime(
 		if (url.includes("/usage?")) {
 			return options.usageResponse ?? new Response(JSON.stringify(options.usage ?? { usage: [] }), { status: 200 });
 		}
+		catalogRequestCount += 1;
+		if (catalogRequestCount === 2 && options.sessionCatalogResponse) return options.sessionCatalogResponse;
 		return catalogResponse();
 	});
 	vi.stubGlobal("fetch", fetchMock);
@@ -325,10 +342,26 @@ function createRuntime(
 	return { context, fetchMock, on, setStatus };
 }
 
+test("session_start does not request balance after switching away during catalog refresh", async () => {
+	const sessionCatalogResponse = deferred<Response>();
+	const runtime = createRuntime({ apiKey: "api-key", sessionCatalogResponse: sessionCatalogResponse.promise });
+
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
+	const sessionStart = handler(runtime.on, "session_start")({}, runtime.context);
+	await vi.waitFor(() => expect(runtime.fetchMock).toHaveBeenCalledTimes(2));
+
+	runtime.context.model.provider = "other";
+	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
+	sessionCatalogResponse.resolve(catalogResponse());
+	await sessionStart;
+
+	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).endsWith("/balance"))).toBe(false);
+});
+
 test("session_start refreshes the API-key catalog and credits", async () => {
 	const runtime = createRuntime({ apiKey: "api-key", organizationId: "org-id" });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "session_start")({}, runtime.context);
 
 	expect(runtime.fetchMock.mock.calls).toEqual([
@@ -370,7 +403,7 @@ test.each([
 ])("%s refreshes API-key credits", async (event, payload) => {
 	const runtime = createRuntime({ apiKey: "api-key", organizationId: "org-id" });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, event)(payload, runtime.context);
 
 	expect(runtime.fetchMock.mock.calls[1]).toEqual([
@@ -397,7 +430,7 @@ test.each([
 		const runtime = createRuntime(runtimeOptions);
 		const context = { ...runtime.context, ...contextOverrides };
 
-		await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+		await kiloExtension(extensionApi(vi.fn(), runtime.on));
 		await handler(runtime.on, event)(payload, context);
 
 		expect(runtime.fetchMock).toHaveBeenCalledTimes(expectedFetchCount);
@@ -427,7 +460,7 @@ test.each([
 ])("before_agent_start handles %s Kilo access", async (_name, auth, apiKey, expected) => {
 	const runtime = createRuntime({ auth, apiKey });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	const beforeAgentStart = handler(runtime.on, "before_agent_start");
 	await expect(beforeAgentStart({}, { model: { provider: "kilo" } })).resolves.toEqual(expected);
 	await expect(beforeAgentStart({}, { model: { provider: "kilo" } })).resolves.toBeUndefined();
@@ -436,7 +469,7 @@ test.each([
 test("does not request usage or set a usage status by default", async () => {
 	const runtime = createRuntime({ apiKey: "api-key" });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "session_start")({}, runtime.context);
 	await handler(runtime.on, "turn_end")({}, runtime.context);
 
@@ -451,7 +484,7 @@ test.each(["1", "true", "yes", "day"])("%s enables daily usage status refreshes"
 		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 1_234_567 }] },
 	});
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "session_start")({}, runtime.context);
 
 	await vi.waitFor(() => {
@@ -464,7 +497,7 @@ test("turn_end skips ambient API calls for another provider", async () => {
 	vi.stubEnv("KILO_PI_USAGE", "day");
 	const runtime = createRuntime({ apiKey: "api-key", provider: "other" });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "turn_end")({}, runtime.context);
 
 	expect(runtime.fetchMock).toHaveBeenCalledTimes(1);
@@ -476,7 +509,7 @@ test("the display override keeps turn-related ambient API calls enabled", async 
 	vi.stubEnv("KILO_PI_USAGE", "day");
 	const runtime = createRuntime({ apiKey: "api-key", provider: "other" });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "turn_end")({}, runtime.context);
 
 	await vi.waitFor(() => expect(runtime.fetchMock).toHaveBeenCalledTimes(3));
@@ -489,7 +522,7 @@ test("turn_end schedules an enabled daily usage refresh", async () => {
 		usage: { usage: [{ date: new Date().toISOString().slice(0, 10), total_cost: 2_000_000 }] },
 	});
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "turn_end")({}, runtime.context);
 
 	await vi.waitFor(() => {
@@ -501,7 +534,7 @@ test("switching providers prevents an in-flight balance refresh from republishin
 	const balanceResponse = deferred<Response>();
 	const runtime = createRuntime({ apiKey: "api-key", balanceResponse: balanceResponse.promise });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	const turnEnd = handler(runtime.on, "turn_end")({}, runtime.context);
 	runtime.context.model.provider = "other";
 	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
@@ -516,7 +549,7 @@ test("switching providers prevents an in-flight usage refresh from republishing 
 	const usageResponse = deferred<Response>();
 	const runtime = createRuntime({ apiKey: "api-key", usageResponse: usageResponse.promise });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await handler(runtime.on, "turn_end")({}, runtime.context);
 	runtime.context.model.provider = "other";
 	await handler(runtime.on, "model_select")({ model: { provider: "other" } }, runtime.context);
@@ -536,7 +569,7 @@ test("turn_end does not wait for an enabled usage response", async () => {
 	const usageResponse = deferred<Response>();
 	const runtime = createRuntime({ apiKey: "api-key", usageResponse: usageResponse.promise });
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	await expect(handler(runtime.on, "turn_end")({}, runtime.context)).resolves.toBeUndefined();
 	expect(runtime.fetchMock.mock.calls.some(([url]) => String(url).includes("/usage?"))).toBe(true);
 
@@ -554,7 +587,7 @@ test("turn_end does not wait for an enabled usage response", async () => {
 test("before_agent_start does not consume the notice for another provider", async () => {
 	const runtime = createRuntime();
 
-	await kiloExtension({ registerProvider: vi.fn(), on: runtime.on } as never);
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
 	const beforeAgentStart = handler(runtime.on, "before_agent_start");
 	await expect(beforeAgentStart({}, { model: { provider: "other" } })).resolves.toBeUndefined();
 	await expect(beforeAgentStart({}, { model: { provider: "kilo" } })).resolves.toMatchObject({

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -6,8 +6,8 @@ import { expect, test } from "vitest";
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJson = JSON.parse(readFileSync(resolve(repositoryRoot, "package.json"), "utf8"));
 
-test("declares the first calendar-versioned release", () => {
-	expect(packageJson.version).toBe("2026.08.2");
+test("declares the current calendar-versioned release", () => {
+	expect(packageJson.version).toBe("2026.09.0");
 });
 
 test("declared Pi extension entry points exist", () => {


### PR DESCRIPTION
Hide Kilo's custom footer, credits, and usage statuses by default when the selected model uses another provider. Switching back to Kilo restores configured usage and credits immediately.

This is an intentional breaking behavior change. Set `display.showForOtherProviders` to `true` or `KILO_PI_SHOW_FOR_OTHER_PROVIDERS=1` to preserve the previous always-visible behavior.

Presentation-related balance and usage requests are suppressed while ambient Kilo UI is hidden. Model catalog requests remain unaffected.

Release: `v2026.09.0`.
