### PR TITLE
Feat/theme responsive footer statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+### Added
+
+- Recolor Kilo credit and usage statuses immediately when Pi switches themes.
+
 ## [2026.09.0] - 2026-09-03
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Release versions use calendar versioning: `YYYY.MM.PATCH`. `PATCH` starts at `0`
 
 ## [Unreleased]
 
+## [2026.09.1] - 2026-09-10
+
 ### Added
 
 - Recolor Kilo credit and usage statuses immediately when Pi switches themes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kilocode/kilo-pi-provider",
-      "version": "2026.09.0",
+      "version": "2026.09.1",
       "license": "BSL-1.0",
       "dependencies": {
         "typebox": "1.3.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kilocode/kilo-pi-provider",
-  "version": "2026.09.0",
+  "version": "2026.09.1",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
 import { loadKiloPreferences } from "./config.ts";
 import { installCustomFooter } from "./footer.ts";
 import { streamKiloResponses } from "./responses.ts";
+import { createThemeStatusPublisher } from "./theme-status.ts";
 
 import { createUsageRefresher } from "./usage.ts";
 
@@ -142,11 +143,12 @@ export default async function (pi: KiloExtensionApi) {
 
 	let kiloFooterInstalled = false;
 	let ambientUiRevision = 0;
+	const themeStatuses = createThemeStatusPublisher();
 	const shouldShowAmbientKiloUi = (provider: string | undefined): boolean =>
 		provider === "kilo" || preferences.display.showForOtherProviders;
 
 	const clearAmbientKiloStatuses = (ctx: ExtensionContext): void => {
-		for (const key of KILO_STATUS_KEYS) ctx.ui.setStatus(key, undefined);
+		themeStatuses.clear(ctx, KILO_STATUS_KEYS);
 	};
 
 	const reconcileAmbientKiloUi = (ctx: ExtensionContext, provider: string | undefined): boolean => {
@@ -171,7 +173,7 @@ export default async function (pi: KiloExtensionApi) {
 
 	const publishCredits = (ctx: ExtensionContext, balance: number, revision: number): void => {
 		if (revision !== ambientUiRevision || !shouldShowAmbientKiloUi(ctx.model?.provider)) return;
-		ctx.ui.setStatus("kilo-credits", ctx.ui.theme.fg("accent", `💰 ${formatCredits(balance)}`));
+		themeStatuses.set(ctx, "kilo-credits", `💰 ${formatCredits(balance)}`);
 	};
 
 	// Fetch models at load time so the provider is immediately usable for
@@ -260,6 +262,7 @@ export default async function (pi: KiloExtensionApi) {
 	// After session starts, pre-fetch all models if already logged in so
 	// modifyModels has data to work with. Also fetch and display credits.
 	pi.on("session_start", async (_event, ctx) => {
+		themeStatuses.install(ctx);
 		preferences = loadKiloPreferences({
 			cwd: ctx.cwd ?? process.cwd(),
 			projectTrusted: ctx.isProjectTrusted?.() ?? false,
@@ -271,14 +274,13 @@ export default async function (pi: KiloExtensionApi) {
 
 		// Clear a stale credit status after logout when an interactive UI is available.
 		if (!access) {
-			if (ctx.hasUI) ctx.ui.setStatus("kilo-credits", undefined);
+			if (ctx.hasUI) themeStatuses.set(ctx, "kilo-credits", undefined);
 			return;
 		}
 
 		if (showAmbientUi && ctx.hasUI && usagePeriods.length > 0) {
 			usageRefresher.refresh(access, usagePeriods, {
-				setStatus: (key, value) => ctx.ui.setStatus(key, value),
-				accent: (text) => ctx.ui.theme.fg("accent", text),
+				setStatus: (key, value) => themeStatuses.set(ctx, key, value),
 			});
 		}
 
@@ -328,8 +330,7 @@ export default async function (pi: KiloExtensionApi) {
 		const usagePeriods = preferences.usage.periods;
 		if (usagePeriods.length > 0) {
 			usageRefresher.refresh(access, usagePeriods, {
-				setStatus: (key, value) => ctx.ui.setStatus(key, value),
-				accent: (text) => ctx.ui.theme.fg("accent", text),
+				setStatus: (key, value) => themeStatuses.set(ctx, key, value),
 			});
 		}
 
@@ -357,8 +358,7 @@ export default async function (pi: KiloExtensionApi) {
 
 		if (usagePeriods.length > 0) {
 			usageRefresher.refresh(access, usagePeriods, {
-				setStatus: (key, value) => ctx.ui.setStatus(key, value),
-				accent: (text) => ctx.ui.theme.fg("accent", text),
+				setStatus: (key, value) => themeStatuses.set(ctx, key, value),
 			});
 		}
 
@@ -371,6 +371,10 @@ export default async function (pi: KiloExtensionApi) {
 		} catch (error) {
 			console.warn("[kilo] Failed to fetch balance on turn end:", error instanceof Error ? error.message : error);
 		}
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		themeStatuses.dispose(ctx);
 	});
 
 	// On first use of a Kilo model without login, print ToS notice.

--- a/src/theme-status.ts
+++ b/src/theme-status.ts
@@ -1,0 +1,61 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const THEME_SYNC_WIDGET_KEY = "kilo-theme-sync";
+const THEME_SYNC_WIDGET_OPTIONS = { placement: "belowEditor" } as const;
+
+type ThemeStatusContext = Pick<ExtensionContext, "hasUI" | "mode"> & {
+	ui: Pick<ExtensionContext["ui"], "setStatus" | "setWidget"> & {
+		theme: Pick<ExtensionContext["ui"]["theme"], "fg" | "getFgAnsi">;
+	};
+};
+
+/**
+ * Publishes themed status strings while retaining their raw text so colors can
+ * be regenerated when Pi invalidates mounted components after a theme change.
+ */
+export function createThemeStatusPublisher() {
+	const statusText = new Map<string, string>();
+
+	const set = (ctx: ThemeStatusContext, key: string, text: string | undefined): void => {
+		if (text === undefined) {
+			statusText.delete(key);
+			ctx.ui.setStatus(key, undefined);
+			return;
+		}
+
+		statusText.set(key, text);
+		ctx.ui.setStatus(key, ctx.ui.theme.fg("accent", text));
+	};
+
+	return {
+		set,
+		clear(ctx: ThemeStatusContext, keys: readonly string[]): void {
+			statusText.clear();
+			for (const key of keys) ctx.ui.setStatus(key, undefined);
+		},
+		install(ctx: ThemeStatusContext): void {
+			if (!ctx.hasUI || ctx.mode !== "tui") return;
+
+			ctx.ui.setWidget(
+				THEME_SYNC_WIDGET_KEY,
+				(_tui, theme) => {
+					let accent = theme.getFgAnsi("accent");
+					return {
+						render: () => [],
+						invalidate() {
+							const nextAccent = theme.getFgAnsi("accent");
+							if (nextAccent === accent) return;
+							accent = nextAccent;
+							for (const [key, text] of statusText) set(ctx, key, text);
+						},
+					};
+				},
+				THEME_SYNC_WIDGET_OPTIONS,
+			);
+		},
+		dispose(ctx: ThemeStatusContext): void {
+			statusText.clear();
+			if (ctx.mode === "tui") ctx.ui.setWidget(THEME_SYNC_WIDGET_KEY, undefined, THEME_SYNC_WIDGET_OPTIONS);
+		},
+	};
+}

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -7,7 +7,6 @@ const USAGE_STATUS_PREFIX = "kilo-usage-";
 
 export interface UsageStatusPresentation {
 	setStatus(key: string, value: string | undefined): void;
-	accent(text: string): string;
 }
 
 interface UsageRefreshRequest {
@@ -85,10 +84,7 @@ export function createUsageRefresher(options: UsageRefresherOptions) {
 
 			for (const period of request.periods) {
 				const spend = sumUsageForPeriod(entries, period, now());
-				request.presentation.setStatus(
-					getUsageStatusKey(period),
-					request.presentation.accent(formatUsage(spend, period)),
-				);
+				request.presentation.setStatus(getUsageStatusKey(period), formatUsage(spend, period));
 			}
 		} catch {
 			// Usage is a background status; never let it reject a Pi lifecycle handler.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -326,15 +326,37 @@ function createRuntime(
 	vi.stubGlobal("fetch", fetchMock);
 	const on = vi.fn();
 	const setStatus = vi.fn();
+	const setWidget = vi.fn();
+	const theme = {
+		fg: vi.fn((_tone: string, text: string) => text),
+		getFgAnsi: vi.fn(() => "dark-accent"),
+	};
 	const context = {
 		model: { provider: options.provider ?? "kilo" },
+		mode: "tui",
 		hasUI: true,
-		ui: { setFooter: vi.fn(), setStatus, theme: { fg: vi.fn((_tone, text) => text) } },
+		ui: { setFooter: vi.fn(), setStatus, setWidget, theme },
 		modelRegistry: { registerProvider: vi.fn() },
 	};
 
-	return { context, fetchMock, on, setStatus };
+	return { context, fetchMock, on, setStatus, setWidget, theme };
 }
+
+test("session lifecycle installs and removes theme status synchronization", async () => {
+	const runtime = createRuntime();
+
+	await kiloExtension(extensionApi(vi.fn(), runtime.on));
+	await handler(runtime.on, "session_start")({}, runtime.context);
+
+	expect(runtime.setWidget).toHaveBeenCalledWith("kilo-theme-sync", expect.any(Function), {
+		placement: "belowEditor",
+	});
+
+	await handler(runtime.on, "session_shutdown")({}, runtime.context);
+	expect(runtime.setWidget).toHaveBeenLastCalledWith("kilo-theme-sync", undefined, {
+		placement: "belowEditor",
+	});
+});
 
 test("session_start does not request balance after switching away during catalog refresh", async () => {
 	const sessionCatalogResponse = deferred<Response>();

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -7,7 +7,7 @@ const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const packageJson = JSON.parse(readFileSync(resolve(repositoryRoot, "package.json"), "utf8"));
 
 test("declares the current calendar-versioned release", () => {
-	expect(packageJson.version).toBe("2026.09.0");
+	expect(packageJson.version).toBe("2026.09.1");
 });
 
 test("declared Pi extension entry points exist", () => {

--- a/test/theme-status.test.ts
+++ b/test/theme-status.test.ts
@@ -1,0 +1,118 @@
+import { expect, test, vi } from "vitest";
+import { createThemeStatusPublisher } from "../src/theme-status.ts";
+
+function createFixture(mode: "tui" | "rpc" = "tui", hasUI = true) {
+	let accent = "dark";
+	const setStatus = vi.fn();
+	const setWidget = vi.fn();
+	const theme = {
+		fg: vi.fn((tone: string, text: string) => `<${accent}:${tone}>${text}</${accent}>`),
+		getFgAnsi: vi.fn(() => accent),
+	};
+	const context = { hasUI, mode, ui: { setStatus, setWidget, theme } };
+
+	return {
+		context,
+		setStatus,
+		setWidget,
+		theme,
+		setAccent(value: string) {
+			accent = value;
+		},
+	};
+}
+
+test("recolors published statuses when Pi invalidates the theme sync component", () => {
+	const fixture = createFixture();
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+	publisher.set(fixture.context, "kilo-credits", "💰 $12.34");
+
+	expect(fixture.setWidget).toHaveBeenCalledWith("kilo-theme-sync", expect.any(Function), {
+		placement: "belowEditor",
+	});
+	expect(fixture.setStatus).toHaveBeenLastCalledWith("kilo-credits", "<dark:accent>💰 $12.34</dark>");
+
+	const factory = fixture.setWidget.mock.calls[0]?.[1];
+	const component = factory({}, fixture.theme);
+	fixture.setAccent("light");
+	component.invalidate();
+
+	expect(component.render()).toEqual([]);
+	expect(fixture.setStatus).toHaveBeenLastCalledWith("kilo-credits", "<light:accent>💰 $12.34</light>");
+});
+
+test("does not republish statuses for unrelated component invalidations", () => {
+	const fixture = createFixture();
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+	publisher.set(fixture.context, "kilo-credits", "credits");
+
+	const factory = fixture.setWidget.mock.calls[0]?.[1];
+	const component = factory({}, fixture.theme);
+	component.invalidate();
+
+	expect(fixture.setStatus).toHaveBeenCalledOnce();
+});
+
+test("clears raw status state and removes the sync component on disposal", () => {
+	const fixture = createFixture();
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+	publisher.set(fixture.context, "kilo-credits", "credits");
+
+	const factory = fixture.setWidget.mock.calls[0]?.[1];
+	const component = factory({}, fixture.theme);
+	publisher.dispose(fixture.context);
+	fixture.setAccent("light");
+	component.invalidate();
+
+	expect(fixture.setStatus).toHaveBeenCalledOnce();
+	expect(fixture.setWidget).toHaveBeenLastCalledWith("kilo-theme-sync", undefined, {
+		placement: "belowEditor",
+	});
+});
+
+test.each([
+	["RPC mode", "rpc" as const, true],
+	["a context without UI", "tui" as const, false],
+])("does not mount a TUI component in %s", (_name, mode, hasUI) => {
+	const fixture = createFixture(mode, hasUI);
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+
+	expect(fixture.setWidget).not.toHaveBeenCalled();
+});
+
+test("clears published statuses and forgets their raw text", () => {
+	const fixture = createFixture();
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+	publisher.set(fixture.context, "kilo-credits", "credits");
+	publisher.clear(fixture.context, ["kilo-credits", "kilo-usage-day"]);
+
+	const factory = fixture.setWidget.mock.calls[0]?.[1];
+	const component = factory({}, fixture.theme);
+	fixture.setAccent("light");
+	component.invalidate();
+
+	expect(fixture.setStatus).toHaveBeenNthCalledWith(2, "kilo-credits", undefined);
+	expect(fixture.setStatus).toHaveBeenNthCalledWith(3, "kilo-usage-day", undefined);
+	expect(fixture.setStatus).toHaveBeenCalledTimes(3);
+});
+
+test("clearing one status removes it from later theme refreshes", () => {
+	const fixture = createFixture();
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+	publisher.set(fixture.context, "kilo-credits", "credits");
+	publisher.set(fixture.context, "kilo-credits", undefined);
+
+	const factory = fixture.setWidget.mock.calls[0]?.[1];
+	const component = factory({}, fixture.theme);
+	fixture.setAccent("light");
+	component.invalidate();
+
+	expect(fixture.setStatus).toHaveBeenCalledTimes(2);
+	expect(fixture.setStatus).toHaveBeenLastCalledWith("kilo-credits", undefined);
+});

--- a/test/theme-status.test.ts
+++ b/test/theme-status.test.ts
@@ -73,11 +73,16 @@ test("clears raw status state and removes the sync component on disposal", () =>
 	});
 });
 
-test.each([
-	["RPC mode", "rpc" as const, true],
-	["a context without UI", "tui" as const, false],
-])("does not mount a TUI component in %s", (_name, mode, hasUI) => {
-	const fixture = createFixture(mode, hasUI);
+test("does not mount a TUI component in RPC mode", () => {
+	const fixture = createFixture("rpc");
+	const publisher = createThemeStatusPublisher();
+	publisher.install(fixture.context);
+
+	expect(fixture.setWidget).not.toHaveBeenCalled();
+});
+
+test("does not mount a TUI component without a UI", () => {
+	const fixture = createFixture("tui", false);
 	const publisher = createThemeStatusPublisher();
 	publisher.install(fixture.context);
 

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -49,7 +49,7 @@ describe("createUsageRefresher", () => {
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
 
-		refresher.refresh(access, ["day"], { setStatus, accent: (text) => text });
+		refresher.refresh(access, ["day"], { setStatus });
 
 		await vi.waitFor(() => {
 			expect(setStatus).toHaveBeenCalledWith("kilo-usage-day", "💸 $1.23 today");
@@ -69,7 +69,7 @@ describe("createUsageRefresher", () => {
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
 
-		refresher.refresh(access, [period], { setStatus, accent: (text) => text });
+		refresher.refresh(access, [period], { setStatus });
 
 		await vi.waitFor(() => {
 			expect(setStatus).toHaveBeenCalledWith(`kilo-usage-${period}`, expectedStatus);
@@ -87,7 +87,7 @@ describe("createUsageRefresher", () => {
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
 
-		refresher.refresh(access, ["week", "month"], { setStatus, accent: (text) => text });
+		refresher.refresh(access, ["week", "month"], { setStatus });
 
 		await vi.waitFor(() => {
 			expect(setStatus).toHaveBeenCalledWith("kilo-usage-week", "💸 $3.00 this week");
@@ -100,7 +100,7 @@ describe("createUsageRefresher", () => {
 		const fetchUsageEntries = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries });
 
-		refresher.refresh(access, [], { setStatus: vi.fn(), accent: (text) => text });
+		refresher.refresh(access, [], { setStatus: vi.fn() });
 
 		expect(fetchUsageEntries).not.toHaveBeenCalled();
 	});
@@ -110,7 +110,7 @@ describe("createUsageRefresher", () => {
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries });
 
-		refresher.refresh(access, ["day"], { setStatus, accent: (text) => text });
+		refresher.refresh(access, ["day"], { setStatus });
 
 		await vi.waitFor(() => expect(fetchUsageEntries).toHaveBeenCalledOnce());
 		expect(setStatus).not.toHaveBeenCalled();
@@ -122,7 +122,7 @@ describe("createUsageRefresher", () => {
 		const fetchUsageEntries = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
 		const setStatus = vi.fn();
 		const refresher = createUsageRefresher({ fetchUsageEntries, now: () => today });
-		const presentation = { setStatus, accent: (text: string) => text };
+		const presentation = { setStatus };
 
 		refresher.refresh(access, ["day"], presentation);
 		refresher.refresh({ token: "newest-token" }, ["day"], presentation);


### PR DESCRIPTION
 Kilo’s footer credit and usage colors stayed on the previous theme after Pi switched between dark and light modes. They only refreshed after the
 next agent turn.

 This change makes those statuses update immediately with Pi’s active theme by responding to Pi’s component invalidation lifecycle—without continuous
 polling.

 Also prepares the 2026.09.1 feature release.